### PR TITLE
fix: fix redis container can't run

### DIFF
--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -25,8 +25,7 @@ services:
       - redis_network
     ports:
       - "6379:6379"
-    command:
-      - redis-server --bind 0.0.0.0 --port 6379
+    command: redis-server --bind 0.0.0.0 --port 6379
     volumes:
       - redis_data:/data
     environment:


### PR DESCRIPTION
fix redis container can't run in docker compase line command: 
 - redis-server --bind 0.0.0.0 --port 6379
