### PR TITLE
feat(admin/filters): Implement CRUD for Filter Brands and fix pagination

### DIFF
--- a/backend/public/openapi.json
+++ b/backend/public/openapi.json
@@ -85,7 +85,26 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/LoginSuccessResponse"
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Register successful"
+                    },
+                    "result": {
+                      "type": "object",
+                      "properties": {
+                        "access_token": {
+                          "type": "string",
+                          "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiNjA5..."
+                        },
+                        "refresh_token": {
+                          "type": "string",
+                          "example": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiNjA5..."
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -2996,7 +3015,7 @@
     "/admin/manage-filters/create-new-filter-brand": {
       "post": {
         "tags": [
-          "Admin"
+          "Admin - Filter Management"
         ],
         "summary": "(Admin) Create a New Filter Brand",
         "security": [
@@ -3455,21 +3474,27 @@
           "email": {
             "type": "string",
             "format": "email",
-            "example": "john.doe@example.com"
+            "example": "user@example.com"
           },
           "password": {
             "type": "string",
             "format": "password",
+            "example": "password123",
             "minLength": 8,
-            "maxLength": 30,
-            "example": "Str0ngP@sswOrd"
+            "maxLength": 30
           },
           "confirm_password": {
             "type": "string",
             "format": "password",
+            "example": "password123",
             "minLength": 8,
-            "maxLength": 30,
-            "example": "Str0ngP@sswOrd"
+            "maxLength": 30
+          },
+          "avatar": {
+            "type": "string",
+            "format": "uri",
+            "description": "Optional avatar URL.",
+            "example": "https://example.com/avatar.jpg"
           }
         }
       },

--- a/backend/public/openapi.json
+++ b/backend/public/openapi.json
@@ -55,6 +55,10 @@
     {
       "name": "Admin",
       "description": "Operations for managing the system."
+    },
+    {
+      "name": "Admin - Filter Management",
+      "description": "Operations for managing product filters, such as brands."
     }
   ],
   "paths": {
@@ -3215,6 +3219,213 @@
           }
         }
       }
+    },
+    "/admin/manage-filters/get-all-filter-brands": {
+      "get": {
+        "tags": [
+          "Admin - Filter Management"
+        ],
+        "summary": "(Admin) Get All Filter Brands",
+        "description": "Retrieves a paginated list of all filterable brands.",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PageQuery"
+          },
+          {
+            "$ref": "#/components/parameters/LimitQuery"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A paginated list of filter brands.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedFilterBrandResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          }
+        }
+      }
+    },
+    "/admin/manage-filters/get-filter-brand-detail/{_id}": {
+      "get": {
+        "tags": [
+          "Admin - Filter Management"
+        ],
+        "summary": "(Admin) Get Filter Brand by ID",
+        "description": "Retrieves the details of a specific filter brand by its ID.",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "_id",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the filter brand to retrieve.",
+            "schema": {
+              "type": "string",
+              "format": "mongoId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Filter brand details retrieved successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FilterBrand"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "404": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          }
+        }
+      }
+    },
+    "/admin/manage-filters/update-filter-brand/{_id}": {
+      "put": {
+        "tags": [
+          "Admin - Filter Management"
+        ],
+        "summary": "(Admin) Update a Filter Brand",
+        "description": "Updates the details of an existing filter brand.",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "_id",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the filter brand to update.",
+            "schema": {
+              "type": "string",
+              "format": "mongoId"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateFilterBrandReqBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Filter brand updated successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FilterBrand"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "404": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "422": {
+            "$ref": "#/components/schemas/ErrorValidationResponse"
+          }
+        }
+      }
+    },
+    "/admin/manage-filters/update-filter-brand-state/{_id}": {
+      "put": {
+        "tags": [
+          "Admin - Filter Management"
+        ],
+        "summary": "(Admin) Update Filter Brand State",
+        "description": "Updates the state of a filter brand (e.g., from ACTIVE to INACTIVE).",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "_id",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the filter brand to update the state for.",
+            "schema": {
+              "type": "string",
+              "format": "mongoId"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DisableFilterBrandReqBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Filter brand state updated successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FilterBrand"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "404": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "422": {
+            "$ref": "#/components/schemas/ErrorValidationResponse"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -4836,6 +5047,108 @@
               "INACTIVE",
               "ACTIVE",
               "OUT_OF_STOCK",
+              "DISCONTINUED"
+            ],
+            "example": "INACTIVE"
+          }
+        }
+      },
+      "FilterBrand": {
+        "type": "object",
+        "properties": {
+          "_id": {
+            "type": "string",
+            "format": "mongoId",
+            "description": "The unique identifier for the filter brand."
+          },
+          "option_name": {
+            "type": "string",
+            "description": "The display name of the brand.",
+            "example": "La Roche-Posay"
+          },
+          "category_name": {
+            "type": "string",
+            "description": "The category this filter belongs to.",
+            "example": "Thương hiệu"
+          },
+          "category_param": {
+            "type": "string",
+            "description": "A URL-friendly version of the brand name.",
+            "example": "la-roche-posay"
+          },
+          "state": {
+            "type": "string",
+            "description": "The current state of the brand.",
+            "enum": [
+              "INACTIVE",
+              "ACTIVE",
+              "COLLABORATION",
+              "PARTNERSHIP",
+              "EXCLUSIVE",
+              "LIMITED_EDITION",
+              "SUSPENDED",
+              "DISCONTINUED"
+            ]
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "PaginatedFilterBrandResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterBrand"
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/PaginatedUserResponse/properties/pagination"
+          }
+        }
+      },
+      "UpdateFilterBrandReqBody": {
+        "type": "object",
+        "description": "Only include the fields that need to be updated.",
+        "properties": {
+          "option_name": {
+            "type": "string",
+            "example": "La Roche-Posay (Official)"
+          },
+          "category_name": {
+            "type": "string",
+            "example": "Thương Hiệu Nổi Bật"
+          },
+          "category_param": {
+            "type": "string",
+            "example": "la-roche-posay-official"
+          }
+        }
+      },
+      "DisableFilterBrandReqBody": {
+        "type": "object",
+        "required": [
+          "state"
+        ],
+        "properties": {
+          "state": {
+            "type": "string",
+            "description": "The new state for the filter brand.",
+            "enum": [
+              "INACTIVE",
+              "ACTIVE",
+              "COLLABORATION",
+              "PARTNERSHIP",
+              "EXCLUSIVE",
+              "LIMITED_EDITION",
+              "SUSPENDED",
               "DISCONTINUED"
             ],
             "example": "INACTIVE"

--- a/backend/src/constants/messages.ts
+++ b/backend/src/constants/messages.ts
@@ -216,6 +216,10 @@ export const ADMIN_MESSAGES = {
   INVALID_PRODUCT_ID: 'Product ID is invalid',
   UPDATE_PRODUCT_STATE_SUCCESS: 'Update product state successfully',
   STATE_IS_REQUIRED: 'State is required',
+  FILTER_BRAND_ID_IS_INVALID: 'Filter brand ID is invalid',
+  FILTER_BRAND_NOT_FOUND: 'Filter brand not found',
+  UPDATE_FILTER_BRAND_SUCCESS: 'Update filter brand successfully',
+  UPDATE_FILTER_BRAND_FAILED: 'Update filter brand failed',
 } as const
 
 export const CART_MESSAGES = {

--- a/backend/src/constants/messages.ts
+++ b/backend/src/constants/messages.ts
@@ -222,7 +222,7 @@ export const ADMIN_MESSAGES = {
   UPDATE_FILTER_BRAND_FAILED: 'Update filter brand failed',
   STATE_MUST_BE_ONE_OF_THE_FILTER_BRAND_STATE:
     'State must be one of the filter brand state: INACTIVE, ACTIVE, COLLABORATION, PARTNERSHIP, EXCLUSIVE, LIMITED_EDITION, SUSPENDED, DISCONTINUED',
-    FILTER_BRAND_DISABLE_SUCCESS: 'Filter brand disabled successfully',
+  FILTER_BRAND_DISABLE_SUCCESS: 'Filter brand disabled successfully'
 } as const
 
 export const CART_MESSAGES = {
@@ -284,3 +284,8 @@ export const ORDER_MESSAGES = {
   NO_CANCELATION_REQUESTED: 'Customer still not request for cancelation',
   GET_ALL_USERS_SUCCESS: 'Get all users successfully'
 } as const
+
+export const COMMON_MESSAGES = {
+  PAGE_MUST_BE_INTEGER_BETWEEN: 'Page must be between',
+  LIMIT_MUST_BE_INTEGER_BETWEEN: 'Limit must be between'
+}

--- a/backend/src/constants/messages.ts
+++ b/backend/src/constants/messages.ts
@@ -220,6 +220,9 @@ export const ADMIN_MESSAGES = {
   FILTER_BRAND_NOT_FOUND: 'Filter brand not found',
   UPDATE_FILTER_BRAND_SUCCESS: 'Update filter brand successfully',
   UPDATE_FILTER_BRAND_FAILED: 'Update filter brand failed',
+  STATE_MUST_BE_ONE_OF_THE_FILTER_BRAND_STATE:
+    'State must be one of the filter brand state: INACTIVE, ACTIVE, COLLABORATION, PARTNERSHIP, EXCLUSIVE, LIMITED_EDITION, SUSPENDED, DISCONTINUED',
+    FILTER_BRAND_DISABLE_SUCCESS: 'Filter brand disabled successfully',
 } as const
 
 export const CART_MESSAGES = {

--- a/backend/src/controllers/filterBrand.controllers.ts
+++ b/backend/src/controllers/filterBrand.controllers.ts
@@ -1,14 +1,42 @@
-import databaseService from "~/services/database.services"
+import databaseService from '~/services/database.services'
 import { Request, Response, NextFunction } from 'express'
-import { sendPaginatedResponse } from "~/utils/pagination.helper"
+import { sendPaginatedResponse } from '~/utils/pagination.helper'
+import { ParamsDictionary } from 'express-serve-static-core'
+import { updateFilterBrandReqBody } from '~/models/requests/Admin.requests'
+import filterBrandService from '~/services/filterBrand.services'
+import { ADMIN_MESSAGES } from '~/constants/messages'
 
 export const getAllFilterBrandsController = async (req: Request, res: Response, next: NextFunction) => {
-  const projection = {
-    option_name: 1,
-    category_name: 1,
-    category_param: 1,
-    _id: 0
+  await sendPaginatedResponse(res, next, databaseService.filterBrand, req.query)
+}
+
+export const updateFilterBrandController = async (
+  req: Request<ParamsDictionary, any, updateFilterBrandReqBody>,
+  res: Response
+) => {
+  try {
+    const { _id } = req.params
+    const result = await filterBrandService.updateFilterBrand(_id, req.body)
+    if (!result) {
+      res.status(404).json({
+        message: ADMIN_MESSAGES.FILTER_BRAND_NOT_FOUND
+      })
+    }
+    res.json({
+      message: ADMIN_MESSAGES.UPDATE_FILTER_BRAND_SUCCESS,
+      result
+    })
+  } catch (error) {
+    if (error instanceof Error) {
+      res.status(500).json({
+        message: ADMIN_MESSAGES.UPDATE_FILTER_BRAND_FAILED,
+        error: error.message
+      })
+    } else {
+      res.status(500).json({
+        message: ADMIN_MESSAGES.UPDATE_FILTER_BRAND_FAILED,
+        error: 'An unexpected error occurred'
+      })
+    }
   }
-  const filter = {}
-  await sendPaginatedResponse(res, next, databaseService.filterBrand, req.query, filter, projection)
 }

--- a/backend/src/controllers/filterBrand.controllers.ts
+++ b/backend/src/controllers/filterBrand.controllers.ts
@@ -2,9 +2,10 @@ import databaseService from '~/services/database.services'
 import { Request, Response, NextFunction } from 'express'
 import { sendPaginatedResponse } from '~/utils/pagination.helper'
 import { ParamsDictionary } from 'express-serve-static-core'
-import { updateFilterBrandReqBody } from '~/models/requests/Admin.requests'
+import { disableFilterBrandReqBody, updateFilterBrandReqBody } from '~/models/requests/Admin.requests'
 import filterBrandService from '~/services/filterBrand.services'
 import { ADMIN_MESSAGES } from '~/constants/messages'
+import { ObjectId } from 'mongodb'
 
 export const getAllFilterBrandsController = async (req: Request, res: Response, next: NextFunction) => {
   await sendPaginatedResponse(res, next, databaseService.filterBrand, req.query)
@@ -39,4 +40,41 @@ export const updateFilterBrandController = async (
       })
     }
   }
+}
+
+export const disableFilterBrandController = async (
+  req: Request<ParamsDictionary, any, disableFilterBrandReqBody>,
+  res: Response
+) => {
+  const { _id } = req.params
+  const { state } = req.body
+
+  const result = await databaseService.filterBrand.findOneAndUpdate(
+    { _id: new ObjectId(_id) },
+    {
+      $set: {
+        state,
+        updated_at: new Date()
+      }
+    },
+    { returnDocument: 'after' }
+  )
+
+  res.json({
+    message: ADMIN_MESSAGES.FILTER_BRAND_DISABLE_SUCCESS,
+    data: result
+  })
+}
+
+export const getFilterBrandByIdController = async (req: Request<{ _id: string }>, res: Response) => {
+  const { _id } = req.params
+
+  const filterBrand = await databaseService.filterBrand.findOne({
+    _id: new ObjectId(_id)
+  })
+
+  if (!filterBrand) {
+    res.status(404).json({ message: ADMIN_MESSAGES.FILTER_BRAND_NOT_FOUND })
+  }
+  res.json({ data: filterBrand })
 }

--- a/backend/src/docs/components/schemas/DisableFilterBrandReqBody.yaml
+++ b/backend/src/docs/components/schemas/DisableFilterBrandReqBody.yaml
@@ -1,0 +1,9 @@
+type: object
+required:
+  - state
+properties:
+  state:
+    type: string
+    description: The new state for the filter brand.
+    enum: [INACTIVE, ACTIVE, COLLABORATION, PARTNERSHIP, EXCLUSIVE, LIMITED_EDITION, SUSPENDED, DISCONTINUED]
+    example: "INACTIVE"

--- a/backend/src/docs/components/schemas/FilterBrand.yaml
+++ b/backend/src/docs/components/schemas/FilterBrand.yaml
@@ -1,0 +1,28 @@
+type: object
+properties:
+  _id:
+    type: string
+    format: mongoId
+    description: The unique identifier for the filter brand.
+  option_name:
+    type: string
+    description: The display name of the brand.
+    example: "La Roche-Posay"
+  category_name:
+    type: string
+    description: The category this filter belongs to.
+    example: "Thương hiệu"
+  category_param:
+    type: string
+    description: A URL-friendly version of the brand name.
+    example: "la-roche-posay"
+  state:
+    type: string
+    description: The current state of the brand.
+    enum: [INACTIVE, ACTIVE, COLLABORATION, PARTNERSHIP, EXCLUSIVE, LIMITED_EDITION, SUSPENDED, DISCONTINUED]
+  created_at:
+    type: string
+    format: date-time
+  updated_at:
+    type: string
+    format: date-time

--- a/backend/src/docs/components/schemas/PaginatedFilterBrandResponse.yaml
+++ b/backend/src/docs/components/schemas/PaginatedFilterBrandResponse.yaml
@@ -1,0 +1,8 @@
+type: object
+properties:
+  data:
+    type: array
+    items:
+      $ref: './FilterBrand.yaml'
+  pagination:
+    $ref: './Pagination.yaml'

--- a/backend/src/docs/components/schemas/RegisterReqBody.yaml
+++ b/backend/src/docs/components/schemas/RegisterReqBody.yaml
@@ -19,16 +19,21 @@ properties:
   email:
     type: string
     format: email
-    example: 'john.doe@example.com'
+    example: 'user@example.com'
   password:
     type: string
     format: password
+    example: 'password123'
     minLength: 8
     maxLength: 30
-    example: 'Str0ngP@sswOrd'
   confirm_password:
     type: string
     format: password
+    example: 'password123'
     minLength: 8
     maxLength: 30
-    example: 'Str0ngP@sswOrd'
+  avatar:
+    type: string
+    format: uri
+    description: 'Optional avatar URL.'
+    example: 'https://example.com/avatar.jpg'

--- a/backend/src/docs/components/schemas/RegisterSuccessResponse.yaml
+++ b/backend/src/docs/components/schemas/RegisterSuccessResponse.yaml
@@ -1,0 +1,14 @@
+type: object
+properties:
+  message:
+    type: string
+    example: "Register successful"
+  result:
+    type: object
+    properties:
+      access_token:
+        type: string
+        example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiNjA5..."
+      refresh_token:
+        type: string
+        example: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiNjA5..."

--- a/backend/src/docs/components/schemas/UpdateFilterBrandReqBody.yaml
+++ b/backend/src/docs/components/schemas/UpdateFilterBrandReqBody.yaml
@@ -1,0 +1,12 @@
+type: object
+description: "Only include the fields that need to be updated."
+properties:
+  option_name:
+    type: string
+    example: "La Roche-Posay (Official)"
+  category_name:
+    type: string
+    example: "Thương Hiệu Nổi Bật"
+  category_param:
+    type: string
+    example: "la-roche-posay-official"

--- a/backend/src/docs/openapi.yaml
+++ b/backend/src/docs/openapi.yaml
@@ -33,6 +33,8 @@ tags:
     description: Operations for managing the user's shopping cart.
   - name: Admin
     description: Operations for managing the system.
+  - name: Admin - Filter Management
+    description: Operations for managing product filters, such as brands.
 paths:
   $ref: './paths/all-paths.yaml'
 
@@ -135,6 +137,16 @@ components:
       $ref: './components/schemas/UpdateUserStateReqBody.yaml'
     UpdateProductStateReqBody:
       $ref: './components/schemas/UpdateProductStateReqBody.yaml'
+    #Filter management
+    #FilterBrand
+    FilterBrand:
+      $ref: './components/schemas/FilterBrand.yaml'
+    PaginatedFilterBrandResponse:
+      $ref: './components/schemas/PaginatedFilterBrandResponse.yaml'
+    UpdateFilterBrandReqBody:
+      $ref: './components/schemas/UpdateFilterBrandReqBody.yaml'
+    DisableFilterBrandReqBody:
+      $ref: './components/schemas/DisableFilterBrandReqBody.yaml'
 
     # --- Response Schemas ---
     AuthSuccessResponse:

--- a/backend/src/docs/paths/all-paths.yaml
+++ b/backend/src/docs/paths/all-paths.yaml
@@ -15,7 +15,7 @@
         content:
           application/json:
             schema:
-              $ref: '../components/schemas/LoginSuccessResponse.yaml'
+              $ref: '../components/schemas/RegisterSuccessResponse.yaml'
       '422':
         description: Validation error (e.g., email exists, password mismatch).
         content:
@@ -797,14 +797,14 @@
                   example: 1
                 return_message:
                   type: string
-                  example: "Success"
+                  example: 'Success'
                 order_url:
                   type: string
                   format: uri
-                  example: "https://sbgateway.zalopay.vn/openinapp?order=..."
+                  example: 'https://sbgateway.zalopay.vn/openinapp?order=...'
                 zp_trans_token:
                   type: string
-                  example: "240624000000123_1a2b3c4d"
+                  example: '240624000000123_1a2b3c4d'
       '400':
         description: Bad Request (e.g., missing orderDetails).
         content:
@@ -849,14 +849,14 @@
               properties:
                 message:
                   type: string
-                  example: "Success"
+                  example: 'Success'
                 data:
                   type: object
                   properties:
                     paymentUrl:
                       type: string
                       format: uri
-                      example: "https://sandbox.vnpayment.vn/paymentv2/vpcpay.html?vnp_Amount=..."
+                      example: 'https://sandbox.vnpayment.vn/paymentv2/vpcpay.html?vnp_Amount=...'
       '401':
         description: Unauthorized. Access token is missing or invalid.
         content:
@@ -990,7 +990,7 @@
               properties:
                 message:
                   type: string
-                  example: "Get all your orders successfully"
+                  example: 'Get all your orders successfully'
                 result:
                   type: array
                   items:
@@ -1768,7 +1768,7 @@
 # ======================= FILTER MANAGEMENT =======================
 /admin/manage-filters/create-new-filter-brand:
   post:
-    tags: [Admin]
+    tags: [Admin - Filter Management]
     summary: (Admin) Create a New Filter Brand
     security:
       - BearerAuth: []
@@ -1823,7 +1823,7 @@
               properties:
                 message:
                   type: string
-                  example: "Update user state successfully"
+                  example: 'Update user state successfully'
                 data:
                   $ref: '../components/schemas/User.yaml'
       '400':
@@ -1876,7 +1876,7 @@
               properties:
                 message:
                   type: string
-                  example: "Update product state successfully"
+                  example: 'Update product state successfully'
                 data:
                   $ref: '../components/schemas/Product.yaml'
       '401':

--- a/backend/src/docs/paths/all-paths.yaml
+++ b/backend/src/docs/paths/all-paths.yaml
@@ -1903,3 +1903,128 @@
           application/json:
             schema:
               $ref: '../components/schemas/ErrorValidationResponse.yaml'
+
+/admin/manage-filters/get-all-filter-brands:
+  get:
+    tags: [Admin - Filter Management]
+    summary: (Admin) Get All Filter Brands
+    description: Retrieves a paginated list of all filterable brands.
+    security:
+      - BearerAuth: []
+    parameters:
+      - $ref: '../openapi.yaml#/components/parameters/PageQuery'
+      - $ref: '../openapi.yaml#/components/parameters/LimitQuery'
+    responses:
+      '200':
+        description: A paginated list of filter brands.
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/PaginatedFilterBrandResponse.yaml'
+      '401':
+        $ref: '../components/schemas/ErrorStatusResponse.yaml'
+      '403':
+        $ref: '../components/schemas/ErrorStatusResponse.yaml'
+
+/admin/manage-filters/get-filter-brand-detail/{_id}:
+  get:
+    tags: [Admin - Filter Management]
+    summary: (Admin) Get Filter Brand by ID
+    description: Retrieves the details of a specific filter brand by its ID.
+    security:
+      - BearerAuth: []
+    parameters:
+      - name: _id
+        in: path
+        required: true
+        description: The ID of the filter brand to retrieve.
+        schema:
+          type: string
+          format: mongoId
+    responses:
+      '200':
+        description: Filter brand details retrieved successfully.
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/FilterBrand.yaml'
+      '401':
+        $ref: '../components/schemas/ErrorStatusResponse.yaml'
+      '403':
+        $ref: '../components/schemas/ErrorStatusResponse.yaml'
+      '404':
+        $ref: '../components/schemas/ErrorStatusResponse.yaml'
+
+/admin/manage-filters/update-filter-brand/{_id}:
+  put:
+    tags: [Admin - Filter Management]
+    summary: (Admin) Update a Filter Brand
+    description: Updates the details of an existing filter brand.
+    security:
+      - BearerAuth: []
+    parameters:
+      - name: _id
+        in: path
+        required: true
+        description: The ID of the filter brand to update.
+        schema:
+          type: string
+          format: mongoId
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/UpdateFilterBrandReqBody.yaml'
+    responses:
+      '200':
+        description: Filter brand updated successfully.
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/FilterBrand.yaml'
+      '401':
+        $ref: '../components/schemas/ErrorStatusResponse.yaml'
+      '403':
+        $ref: '../components/schemas/ErrorStatusResponse.yaml'
+      '404':
+        $ref: '../components/schemas/ErrorStatusResponse.yaml'
+      '422':
+        $ref: '../components/schemas/ErrorValidationResponse.yaml'
+
+/admin/manage-filters/update-filter-brand-state/{_id}:
+  put:
+    tags: [Admin - Filter Management]
+    summary: (Admin) Update Filter Brand State
+    description: Updates the state of a filter brand (e.g., from ACTIVE to INACTIVE).
+    security:
+      - BearerAuth: []
+    parameters:
+      - name: _id
+        in: path
+        required: true
+        description: The ID of the filter brand to update the state for.
+        schema:
+          type: string
+          format: mongoId
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/DisableFilterBrandReqBody.yaml'
+    responses:
+      '200':
+        description: Filter brand state updated successfully.
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/FilterBrand.yaml'
+      '401':
+        $ref: '../components/schemas/ErrorStatusResponse.yaml'
+      '403':
+        $ref: '../components/schemas/ErrorStatusResponse.yaml'
+      '404':
+        $ref: '../components/schemas/ErrorStatusResponse.yaml'
+      '422':
+        $ref: '../components/schemas/ErrorValidationResponse.yaml'

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -36,6 +36,7 @@ app.use(express.urlencoded({ extended: true }))
 databaseService.connect().then(async () => {
   databaseService.indexUsers()
   databaseService.indexVouchers()
+  // databaseService.indexProducts()
 
   await waitForKafkaReady()
   await connectProducer()

--- a/backend/src/middlewares/common.middlewares.ts
+++ b/backend/src/middlewares/common.middlewares.ts
@@ -1,5 +1,9 @@
 import { Response, Request, NextFunction } from 'express'
 import { pick } from 'lodash'
+import { checkSchema } from 'express-validator'
+import { validate } from '~/utils/validation'
+import { COMMON_MESSAGES } from '~/constants/messages'
+
 type FilterKeys<T> = Array<keyof T>
 
 export const filterMiddleware =
@@ -17,3 +21,34 @@ export const parseDateFieldsMiddleware = (fields: string[]) => (req: Request, re
   })
   next()
 }
+
+const MAX_PAGE_LIMIT = 50
+const MAX_ITEMS_PER_PAGE = 20
+export const paginationValidator = validate(
+  checkSchema({
+    page: {
+      in: ['query'],
+      optional: true,
+      isInt: {
+        options: {
+          min: 1,
+          max: MAX_PAGE_LIMIT
+        },
+        errorMessage: `${COMMON_MESSAGES.PAGE_MUST_BE_INTEGER_BETWEEN} 1 and ${MAX_PAGE_LIMIT}`
+      },
+      toInt: true
+    },
+    limit: {
+      in: ['query'],
+      optional: true,
+      isInt: {
+        options: {
+          min: 1,
+          max: MAX_ITEMS_PER_PAGE
+        },
+        errorMessage: `${COMMON_MESSAGES.LIMIT_MUST_BE_INTEGER_BETWEEN}: 1 and ${MAX_ITEMS_PER_PAGE}`
+      },
+      toInt: true
+    }
+  })
+)

--- a/backend/src/middlewares/filterBrand.middlewares.ts
+++ b/backend/src/middlewares/filterBrand.middlewares.ts
@@ -1,0 +1,35 @@
+import { validate } from '~/utils/validation'
+import { checkSchema } from 'express-validator'
+import { ADMIN_MESSAGES } from '~/constants/messages'
+
+export const updateFilterBrandValidator = validate(
+  checkSchema({
+    _id: {
+      in: ['params'],
+      isMongoId: {
+        errorMessage: ADMIN_MESSAGES.FILTER_BRAND_ID_IS_INVALID
+      }
+    },
+    option_name: {
+      optional: true,
+      isString: {
+        errorMessage: ADMIN_MESSAGES.FILTER_BRAND_OPTION_NAME_MUST_BE_A_STRING
+      },
+      trim: true
+    },
+    category_name: {
+      optional: true,
+      isString: {
+        errorMessage: ADMIN_MESSAGES.FILTER_BRAND_CATEGORY_NAME_MUST_BE_A_STRING
+      },
+      trim: true
+    },
+    category_param: {
+      optional: true,
+      isString: {
+        errorMessage: ADMIN_MESSAGES.FILTER_BRAND_CATEGORY_PARAM_MUST_BE_A_STRING
+      },
+      trim: true
+    }
+  })
+)

--- a/backend/src/middlewares/filterBrand.middlewares.ts
+++ b/backend/src/middlewares/filterBrand.middlewares.ts
@@ -1,6 +1,7 @@
 import { validate } from '~/utils/validation'
 import { checkSchema } from 'express-validator'
 import { ADMIN_MESSAGES } from '~/constants/messages'
+import { FilterBrandState } from '~/constants/enums'
 
 export const updateFilterBrandValidator = validate(
   checkSchema({
@@ -30,6 +31,35 @@ export const updateFilterBrandValidator = validate(
         errorMessage: ADMIN_MESSAGES.FILTER_BRAND_CATEGORY_PARAM_MUST_BE_A_STRING
       },
       trim: true
+    }
+  })
+)
+
+export const disableFilterBrandValidator = validate(
+  checkSchema({
+    _id: {
+      in: ['params'],
+      isMongoId: {
+        errorMessage: ADMIN_MESSAGES.FILTER_BRAND_ID_IS_INVALID
+      }
+    },
+    state: {
+      in: ['body'],
+      isIn: {
+        options: [Object.values(FilterBrandState)],
+        errorMessage: ADMIN_MESSAGES.STATE_MUST_BE_ONE_OF_THE_FILTER_BRAND_STATE
+      }
+    }
+  })
+)
+
+export const getFilterBrandByIdValidator = validate(
+  checkSchema({
+    _id: {
+      in: ['params'],
+      isMongoId: {
+        errorMessage: ADMIN_MESSAGES.FILTER_BRAND_ID_IS_INVALID
+      }
     }
   })
 )

--- a/backend/src/models/requests/Admin.requests.ts
+++ b/backend/src/models/requests/Admin.requests.ts
@@ -8,3 +8,16 @@ export interface createNewFilterBrandReqBody {
 export interface UpdateUserStateReqBody {
   verify: UserVerifyStatus
 }
+
+export interface createNewFilterBrandReqBody {
+  option_name: string
+  category_name: string
+  category_param: string
+  state?: FilterBrandState
+}
+
+export interface updateFilterBrandReqBody {
+  option_name: string
+  category_name: string
+  category_param: string
+}

--- a/backend/src/models/requests/Admin.requests.ts
+++ b/backend/src/models/requests/Admin.requests.ts
@@ -21,3 +21,7 @@ export interface updateFilterBrandReqBody {
   category_name: string
   category_param: string
 }
+
+export interface disableFilterBrandReqBody {
+  state: FilterBrandState
+}

--- a/backend/src/routes/admin.routes.ts
+++ b/backend/src/routes/admin.routes.ts
@@ -29,7 +29,7 @@ import {
   inactiveVoucherController,
   getAllVoucherForAdminController
 } from '~/controllers/voucher.controllers'
-import { filterMiddleware, parseDateFieldsMiddleware } from '~/middlewares/common.middlewares'
+import { filterMiddleware, paginationValidator, parseDateFieldsMiddleware } from '~/middlewares/common.middlewares'
 import { createVoucherValidator, updateVoucherValidator, voucherIdValidator } from '~/middlewares/voucher.middlewares'
 import { CreateNewVoucherReqBody, UpdateVoucherReqBody } from '~/models/requests/Vouchers.request'
 import { updateProductReqBody } from '~/models/requests/Product.requests'
@@ -104,7 +104,7 @@ adminRouter.put(
 )
 
 //product management
-adminRouter.get('/manage-products/get-all', accessTokenValidator, isAdminValidator, wrapAsync(getAllProductController))
+adminRouter.get('/manage-products/get-all', accessTokenValidator, isAdminValidator, paginationValidator, wrapAsync(getAllProductController))
 adminRouter.post(
   '/manage-products/create-new-product',
   accessTokenValidator,

--- a/backend/src/routes/admin.routes.ts
+++ b/backend/src/routes/admin.routes.ts
@@ -33,7 +33,9 @@ import { filterMiddleware, parseDateFieldsMiddleware } from '~/middlewares/commo
 import { createVoucherValidator, updateVoucherValidator, voucherIdValidator } from '~/middlewares/voucher.middlewares'
 import { CreateNewVoucherReqBody, UpdateVoucherReqBody } from '~/models/requests/Vouchers.request'
 import { updateProductReqBody } from '~/models/requests/Product.requests'
-import { getAllFilterBrandsController } from '~/controllers/filterBrand.controllers'
+import { getAllFilterBrandsController, updateFilterBrandController } from '~/controllers/filterBrand.controllers'
+import { updateFilterBrandReqBody } from '~/models/requests/Admin.requests'
+import { updateFilterBrandValidator } from '~/middlewares/filterBrand.middlewares'
 
 const adminRouter = Router()
 //user management
@@ -149,7 +151,7 @@ adminRouter.put(
   isAdminValidator,
   updateProductStateValidator,
   wrapAsync(updateProductStateController)
-);
+)
 
 //manage filter
 //filter-brand
@@ -167,4 +169,13 @@ adminRouter.get(
   isAdminValidator,
   wrapAsync(getAllFilterBrandsController)
 )
+adminRouter.put(
+  '/manage-filters/update-filter-brand/:_id',
+  accessTokenValidator,
+  isAdminValidator,
+  filterMiddleware<updateFilterBrandReqBody>(['option_name', 'category_name', 'category_param']),
+  updateFilterBrandValidator,
+  wrapAsync(updateFilterBrandController)
+)
+
 export default adminRouter

--- a/backend/src/routes/admin.routes.ts
+++ b/backend/src/routes/admin.routes.ts
@@ -33,9 +33,9 @@ import { filterMiddleware, parseDateFieldsMiddleware } from '~/middlewares/commo
 import { createVoucherValidator, updateVoucherValidator, voucherIdValidator } from '~/middlewares/voucher.middlewares'
 import { CreateNewVoucherReqBody, UpdateVoucherReqBody } from '~/models/requests/Vouchers.request'
 import { updateProductReqBody } from '~/models/requests/Product.requests'
-import { getAllFilterBrandsController, updateFilterBrandController } from '~/controllers/filterBrand.controllers'
-import { updateFilterBrandReqBody } from '~/models/requests/Admin.requests'
-import { updateFilterBrandValidator } from '~/middlewares/filterBrand.middlewares'
+import { disableFilterBrandController, getAllFilterBrandsController, getFilterBrandByIdController, updateFilterBrandController } from '~/controllers/filterBrand.controllers'
+import { disableFilterBrandReqBody, updateFilterBrandReqBody } from '~/models/requests/Admin.requests'
+import { disableFilterBrandValidator, getFilterBrandByIdValidator, updateFilterBrandValidator } from '~/middlewares/filterBrand.middlewares'
 
 const adminRouter = Router()
 //user management
@@ -169,6 +169,7 @@ adminRouter.get(
   isAdminValidator,
   wrapAsync(getAllFilterBrandsController)
 )
+//update filter brand
 adminRouter.put(
   '/manage-filters/update-filter-brand/:_id',
   accessTokenValidator,
@@ -176,6 +177,23 @@ adminRouter.put(
   filterMiddleware<updateFilterBrandReqBody>(['option_name', 'category_name', 'category_param']),
   updateFilterBrandValidator,
   wrapAsync(updateFilterBrandController)
+)
+//disable filter brand
+adminRouter.put(
+  '/manage-filters/update-filter-brand-state/:_id',
+  accessTokenValidator,
+  isAdminValidator,
+  filterMiddleware<disableFilterBrandReqBody>(['state']),
+  disableFilterBrandValidator,
+  wrapAsync(disableFilterBrandController)
+)
+//get filter brand by id
+adminRouter.get(
+  '/manage-filters/get-filter-brand-detail/:_id',
+  accessTokenValidator,
+  isAdminValidator,
+  getFilterBrandByIdValidator,
+  wrapAsync(getFilterBrandByIdController)
 )
 
 export default adminRouter

--- a/backend/src/services/database.services.ts
+++ b/backend/src/services/database.services.ts
@@ -96,6 +96,18 @@ class DatabaseService {
     await this.vouchers.createIndex({ code: 1 }, { unique: true })
   }
 
+  async indexProducts() {
+    //Index để tối ưu tìm kiếm theo tên sản phẩm `text` index cho phép dùng toán tử $text và $search
+    //await this.products.createIndex({ name_on_list: 'text', engName_on_list: 'text' });
+    
+    //Index để tối ưu sắp xếp cho việc phân trang -1 là sắp xếp giảm dần (mới nhất trước)
+    // await this.products.createIndex({ created_at: -1 });
+
+    //Index cho các trường filter phổ biến
+    //await this.products.createIndex({ filter_brand: 1 });
+    //await this.products.createIndex({ state: 1 });
+  }
+
   get refreshTokens(): Collection<RefreshToken> {
     return this.db.collection(process.env.DB_REFRESH_TOKENS_COLLECTION as string)
   }

--- a/backend/src/services/filterBrand.services.ts
+++ b/backend/src/services/filterBrand.services.ts
@@ -1,6 +1,9 @@
 import { ObjectId } from 'mongodb'
 import { FilterBrandState } from '~/constants/enums'
-import { createNewFilterBrandReqBody } from '~/models/requests/Admin.requests'
+import HTTP_STATUS from '~/constants/httpStatus'
+import { ADMIN_MESSAGES } from '~/constants/messages'
+import { ErrorWithStatus } from '~/models/Errors'
+import { createNewFilterBrandReqBody, updateFilterBrandReqBody } from '~/models/requests/Admin.requests'
 import FilterBrand from '~/models/schemas/FilterBrand.schema'
 import databaseService from '~/services/database.services'
 
@@ -32,6 +35,38 @@ class FilterBrandService {
     console.log(result)
     return result
   }
+
+  async updateFilterBrand(_id: string, payload: updateFilterBrandReqBody) {
+    try {
+      const updatedPayload = { ...payload }
+      const currentDate = new Date()
+      const vietnamTimezoneOffset = 7 * 60
+      const localTime = new Date(currentDate.getTime() + vietnamTimezoneOffset * 60 * 1000)
+      const result = await databaseService.filterBrand.findOneAndUpdate(
+        { _id: new ObjectId(_id) },
+        {
+          $set: {
+            ...updatedPayload,
+            updated_at: localTime
+          }
+        },
+        {
+          returnDocument: 'after'
+        }
+      )
+      return result
+    } catch (error) {
+      throw new ErrorWithStatus({
+        message: ADMIN_MESSAGES.UPDATE_FILTER_BRAND_FAILED,
+        status: HTTP_STATUS.INTERNAL_SERVER_ERROR
+      })
+    }
+  }
+
+
+
+
+
 }
 const filterBrandService = new FilterBrandService()
 export default filterBrandService


### PR DESCRIPTION
Pull Request này triển khai một bộ tính năng quản trị quan trọng, đồng thời sửa chữa hai lỗi ảnh hưởng đến trải nghiệm người dùng và tính toàn vẹn dữ liệu.

Mục tiêu chính là cung cấp cho Admin khả năng quản lý toàn diện các bộ lọc "Thương hiệu" (Filter Brand) và khắc phục các vấn đề về phân trang và lưu trữ dữ liệu sản phẩm đã phát hiện gần đây.

🚀 Feature: Quản lý bộ lọc Thương hiệu (Filter Brand)

GET /admin/manage-filters/get-all-filter-brands: Lấy danh sách tất cả các thương hiệu có phân trang.
GET /admin/manage-filters/get-filter-brand-detail/:_id: Lấy thông tin chi tiết của một thương hiệu theo ID.
PUT /admin/manage-filters/update-filter-brand/:_id: Cập nhật thông tin của một thương hiệu (tên, danh mục, v.v.).
PUT /admin/manage-filters/update-filter-brand-state/:_id: Cập nhật trạng thái của một thương hiệu (ví dụ: ACTIVE, INACTIVE).

🐛 Bug Fix: Phân trang (Pagination)

Vấn đề: Logic validation cho phân trang trước đây quá khắt khe, giới hạn số trang và số lượng item mỗi trang ở mức thấp, gây lỗi khi người dùng muốn xem các trang dữ liệu lớn.
Giải pháp: Tạo middleware paginationValidator mới với các giới hạn hợp lý hơn (page tối đa 50, limit tối đa 20), đảm bảo khả năng duyệt qua toàn bộ dữ liệu mà vẫn bảo vệ hệ thống.

🐛 Bug Fix: Chuyển đổi ObjectId cho Filter sản phẩm

Vấn đề: Khi tạo hoặc cập nhật sản phẩm, các ID của bộ lọc (ví dụ: filter_brand) đang được lưu vào database dưới dạng String thay vì ObjectId, gây ra sai lệch kiểu dữ liệu và có thể ảnh hưởng đến các truy vấn sau này.
Giải pháp: Cập nhật lại product.services.ts để tự động chuyển đổi tất cả các trường filter_* từ String sang ObjectId trước khi lưu vào database.