### PR TITLE
Feature/crud filters and send mail

### DIFF
--- a/backend/public/openapi.json
+++ b/backend/public/openapi.json
@@ -4117,6 +4117,297 @@
           }
         }
       }
+    },
+    "/admin/manage-filters/create-new-filter-hsk-product-type": {
+      "post": {
+        "tags": [
+          "Admin - Filter Product Type"
+        ],
+        "summary": "(Admin) Create a New HSK Product Type Filter",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateFilterHskProductTypeReqBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Filter loại sản phẩm được tạo thành công.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "422": {
+            "$ref": "#/components/schemas/ErrorValidationResponse"
+          }
+        }
+      }
+    },
+    "/admin/manage-filters/get-all-filter-hsk-product-types": {
+      "get": {
+        "tags": [
+          "Admin - Filter Product Type"
+        ],
+        "summary": "(Admin) Get All HSK Product Type Filters",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PageQuery"
+          },
+          {
+            "$ref": "#/components/parameters/LimitQuery"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Trả về danh sách các filter loại sản phẩm.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedFilterHskProductTypeResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          }
+        }
+      }
+    },
+    "/admin/manage-filters/get-filter-hsk-product-type-detail/{_id}": {
+      "get": {
+        "tags": [
+          "Admin - Filter Product Type"
+        ],
+        "summary": "(Admin) Get HSK Product Type Filter by ID",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "mongoId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Chi tiết filter loại sản phẩm.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FilterHskProductType"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "404": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          }
+        }
+      }
+    },
+    "/admin/manage-filters/update-filter-hsk-product-type/{_id}": {
+      "put": {
+        "tags": [
+          "Admin - Filter Product Type"
+        ],
+        "summary": "(Admin) Update an HSK Product Type Filter",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "mongoId"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateFilterHskProductTypeReqBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Filter loại sản phẩm được cập nhật thành công.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FilterHskProductType"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "404": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "422": {
+            "$ref": "#/components/schemas/ErrorValidationResponse"
+          }
+        }
+      }
+    },
+    "/admin/manage-filters/update-filter-hsk-product-type-state/{_id}": {
+      "put": {
+        "tags": [
+          "Admin - Filter Product Type"
+        ],
+        "summary": "(Admin) Update HSK Product Type Filter State",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "mongoId"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DisableFilterHskProductTypeReqBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Trạng thái filter loại sản phẩm được cập nhật thành công.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FilterHskProductType"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "404": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "422": {
+            "$ref": "#/components/schemas/ErrorValidationResponse"
+          }
+        }
+      }
+    },
+    "/admin/manage-filters/search-filter-hsk-product-type": {
+      "get": {
+        "tags": [
+          "Admin - Filter Product Type"
+        ],
+        "summary": "(Admin) Search HSK Product Type Filters by Name",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PageQuery"
+          },
+          {
+            "$ref": "#/components/parameters/LimitQuery"
+          },
+          {
+            "name": "keyword",
+            "in": "query",
+            "description": "Từ khóa tìm kiếm trong tên loại sản phẩm.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Trả về danh sách các filter loại sản phẩm phù hợp.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedFilterHskProductTypeResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -6080,6 +6371,130 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/FilterHskIngredient"
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/PaginatedUserResponse/properties/pagination"
+          }
+        }
+      },
+      "FilterHskProductType": {
+        "type": "object",
+        "description": "Đại diện cho một đối tượng filter Loại Sản Phẩm HSK.",
+        "properties": {
+          "_id": {
+            "type": "string",
+            "format": "mongoId"
+          },
+          "option_name": {
+            "type": "string",
+            "example": "Serum"
+          },
+          "description": {
+            "type": "string",
+            "example": "Tinh chất đặc trị các vấn đề về da"
+          },
+          "category_name": {
+            "type": "string",
+            "example": "Loại Sản Phẩm HSK"
+          },
+          "category_param": {
+            "type": "string",
+            "example": "serum"
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "INACTIVE",
+              "ACTIVE"
+            ]
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "CreateFilterHskProductTypeReqBody": {
+        "type": "object",
+        "required": [
+          "option_name",
+          "category_name",
+          "category_param"
+        ],
+        "properties": {
+          "option_name": {
+            "type": "string",
+            "example": "Kem Chống Nắng"
+          },
+          "description": {
+            "type": "string",
+            "example": "Sản phẩm bảo vệ da khỏi tia UV"
+          },
+          "category_name": {
+            "type": "string",
+            "example": "Loại Sản Phẩm HSK"
+          },
+          "category_param": {
+            "type": "string",
+            "example": "kem-chong-nang"
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "INACTIVE",
+              "ACTIVE"
+            ],
+            "default": "ACTIVE"
+          }
+        }
+      },
+      "UpdateFilterHskProductTypeReqBody": {
+        "type": "object",
+        "description": "Chỉ bao gồm các trường cần cập nhật cho loại sản phẩm.",
+        "properties": {
+          "option_name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "category_name": {
+            "type": "string"
+          },
+          "category_param": {
+            "type": "string"
+          }
+        }
+      },
+      "DisableFilterHskProductTypeReqBody": {
+        "type": "object",
+        "required": [
+          "state"
+        ],
+        "properties": {
+          "state": {
+            "type": "string",
+            "description": "Trạng thái mới cho filter loại sản phẩm.",
+            "enum": [
+              "INACTIVE",
+              "ACTIVE"
+            ],
+            "example": "INACTIVE"
+          }
+        }
+      },
+      "PaginatedFilterHskProductTypeResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterHskProductType"
             }
           },
           "pagination": {

--- a/backend/public/openapi.json
+++ b/backend/public/openapi.json
@@ -4408,6 +4408,297 @@
           }
         }
       }
+    },
+    "/admin/manage-filters/create-new-filter-hsk-size": {
+      "post": {
+        "tags": [
+          "Admin - Filter Size"
+        ],
+        "summary": "(Admin) Create a New HSK Size Filter",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateFilterHskSizeReqBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Filter kích thước được tạo thành công.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "422": {
+            "$ref": "#/components/schemas/ErrorValidationResponse"
+          }
+        }
+      }
+    },
+    "/admin/manage-filters/get-all-filter-hsk-sizes": {
+      "get": {
+        "tags": [
+          "Admin - Filter Size"
+        ],
+        "summary": "(Admin) Get All HSK Size Filters",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PageQuery"
+          },
+          {
+            "$ref": "#/components/parameters/LimitQuery"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Trả về danh sách các filter kích thước.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedFilterHskSizeResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          }
+        }
+      }
+    },
+    "/admin/manage-filters/get-filter-hsk-size-detail/{_id}": {
+      "get": {
+        "tags": [
+          "Admin - Filter Size"
+        ],
+        "summary": "(Admin) Get HSK Size Filter by ID",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "mongoId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Chi tiết filter kích thước.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FilterHskSize"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "404": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          }
+        }
+      }
+    },
+    "/admin/manage-filters/update-filter-hsk-size/{_id}": {
+      "put": {
+        "tags": [
+          "Admin - Filter Size"
+        ],
+        "summary": "(Admin) Update an HSK Size Filter",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "mongoId"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateFilterHskSizeReqBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Filter kích thước được cập nhật thành công.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FilterHskSize"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "404": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "422": {
+            "$ref": "#/components/schemas/ErrorValidationResponse"
+          }
+        }
+      }
+    },
+    "/admin/manage-filters/update-filter-hsk-size-state/{_id}": {
+      "put": {
+        "tags": [
+          "Admin - Filter Size"
+        ],
+        "summary": "(Admin) Update HSK Size Filter State",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "mongoId"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DisableFilterHskSizeReqBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Trạng thái filter kích thước được cập nhật thành công.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FilterHskSize"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "404": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "422": {
+            "$ref": "#/components/schemas/ErrorValidationResponse"
+          }
+        }
+      }
+    },
+    "/admin/manage-filters/search-filter-hsk-size": {
+      "get": {
+        "tags": [
+          "Admin - Filter Size"
+        ],
+        "summary": "(Admin) Search HSK Size Filters by Name",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PageQuery"
+          },
+          {
+            "$ref": "#/components/parameters/LimitQuery"
+          },
+          {
+            "name": "keyword",
+            "in": "query",
+            "description": "Từ khóa tìm kiếm trong tên kích thước.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Trả về danh sách các filter kích thước phù hợp.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedFilterHskSizeResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -6495,6 +6786,119 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/FilterHskProductType"
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/PaginatedUserResponse/properties/pagination"
+          }
+        }
+      },
+      "FilterHskSize": {
+        "type": "object",
+        "description": "Đại diện cho một đối tượng filter Kích thước (Size).",
+        "properties": {
+          "_id": {
+            "type": "string",
+            "format": "mongoId"
+          },
+          "option_name": {
+            "type": "string",
+            "example": "100ml"
+          },
+          "category_name": {
+            "type": "string",
+            "example": "Kích Thước HSK"
+          },
+          "category_param": {
+            "type": "string",
+            "example": "100ml"
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "INACTIVE",
+              "ACTIVE"
+            ]
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "CreateFilterHskSizeReqBody": {
+        "type": "object",
+        "required": [
+          "option_name",
+          "category_name",
+          "category_param"
+        ],
+        "properties": {
+          "option_name": {
+            "type": "string",
+            "example": "250ml"
+          },
+          "category_name": {
+            "type": "string",
+            "example": "Kích Thước HSK"
+          },
+          "category_param": {
+            "type": "string",
+            "example": "250ml"
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "INACTIVE",
+              "ACTIVE"
+            ],
+            "default": "ACTIVE"
+          }
+        }
+      },
+      "UpdateFilterHskSizeReqBody": {
+        "type": "object",
+        "description": "Chỉ bao gồm các trường cần cập nhật cho kích thước.",
+        "properties": {
+          "option_name": {
+            "type": "string"
+          },
+          "category_name": {
+            "type": "string"
+          },
+          "category_param": {
+            "type": "string"
+          }
+        }
+      },
+      "DisableFilterHskSizeReqBody": {
+        "type": "object",
+        "required": [
+          "state"
+        ],
+        "properties": {
+          "state": {
+            "type": "string",
+            "description": "Trạng thái mới cho filter kích thước.",
+            "enum": [
+              "INACTIVE",
+              "ACTIVE"
+            ],
+            "example": "INACTIVE"
+          }
+        }
+      },
+      "PaginatedFilterHskSizeResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterHskSize"
             }
           },
           "pagination": {

--- a/backend/public/openapi.json
+++ b/backend/public/openapi.json
@@ -4699,6 +4699,297 @@
           }
         }
       }
+    },
+    "/admin/manage-filters/create-new-filter-hsk-skin-type": {
+      "post": {
+        "tags": [
+          "Admin - Filter Skin Type"
+        ],
+        "summary": "(Admin) Create a New HSK Skin Type Filter",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateFilterHskSkinTypeReqBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Filter loại da được tạo thành công.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "422": {
+            "$ref": "#/components/schemas/ErrorValidationResponse"
+          }
+        }
+      }
+    },
+    "/admin/manage-filters/get-all-filter-hsk-skin-types": {
+      "get": {
+        "tags": [
+          "Admin - Filter Skin Type"
+        ],
+        "summary": "(Admin) Get All HSK Skin Type Filters",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PageQuery"
+          },
+          {
+            "$ref": "#/components/parameters/LimitQuery"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Trả về danh sách các filter loại da.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedFilterHskSkinTypeResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          }
+        }
+      }
+    },
+    "/admin/manage-filters/get-filter-hsk-skin-type-detail/{_id}": {
+      "get": {
+        "tags": [
+          "Admin - Filter Skin Type"
+        ],
+        "summary": "(Admin) Get HSK Skin Type Filter by ID",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "mongoId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Chi tiết filter loại da.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FilterHskSkinType"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "404": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          }
+        }
+      }
+    },
+    "/admin/manage-filters/update-filter-hsk-skin-type/{_id}": {
+      "put": {
+        "tags": [
+          "Admin - Filter Skin Type"
+        ],
+        "summary": "(Admin) Update an HSK Skin Type Filter",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "mongoId"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateFilterHskSkinTypeReqBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Filter loại da được cập nhật thành công.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FilterHskSkinType"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "404": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "422": {
+            "$ref": "#/components/schemas/ErrorValidationResponse"
+          }
+        }
+      }
+    },
+    "/admin/manage-filters/update-filter-hsk-skin-type-state/{_id}": {
+      "put": {
+        "tags": [
+          "Admin - Filter Skin Type"
+        ],
+        "summary": "(Admin) Update HSK Skin Type Filter State",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "mongoId"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DisableFilterHskSkinTypeReqBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Trạng thái filter loại da được cập nhật thành công.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FilterHskSkinType"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "404": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "422": {
+            "$ref": "#/components/schemas/ErrorValidationResponse"
+          }
+        }
+      }
+    },
+    "/admin/manage-filters/search-filter-hsk-skin-type": {
+      "get": {
+        "tags": [
+          "Admin - Filter Skin Type"
+        ],
+        "summary": "(Admin) Search HSK Skin Type Filters by Name",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PageQuery"
+          },
+          {
+            "$ref": "#/components/parameters/LimitQuery"
+          },
+          {
+            "name": "keyword",
+            "in": "query",
+            "description": "Từ khóa tìm kiếm trong tên loại da.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Trả về danh sách các filter loại da phù hợp.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedFilterHskSkinTypeResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -6899,6 +7190,119 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/FilterHskSize"
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/PaginatedUserResponse/properties/pagination"
+          }
+        }
+      },
+      "FilterHskSkinType": {
+        "type": "object",
+        "description": "Đại diện cho một đối tượng filter Loại Da HSK.",
+        "properties": {
+          "_id": {
+            "type": "string",
+            "format": "mongoId"
+          },
+          "option_name": {
+            "type": "string",
+            "example": "Da Dầu"
+          },
+          "category_name": {
+            "type": "string",
+            "example": "Loại Da HSK"
+          },
+          "category_param": {
+            "type": "string",
+            "example": "da-dau"
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "INACTIVE",
+              "ACTIVE"
+            ]
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "CreateFilterHskSkinTypeReqBody": {
+        "type": "object",
+        "required": [
+          "option_name",
+          "category_name",
+          "category_param"
+        ],
+        "properties": {
+          "option_name": {
+            "type": "string",
+            "example": "Da Hỗn Hợp"
+          },
+          "category_name": {
+            "type": "string",
+            "example": "Loại Da HSK"
+          },
+          "category_param": {
+            "type": "string",
+            "example": "da-hon-hop"
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "INACTIVE",
+              "ACTIVE"
+            ],
+            "default": "ACTIVE"
+          }
+        }
+      },
+      "UpdateFilterHskSkinTypeReqBody": {
+        "type": "object",
+        "description": "Chỉ bao gồm các trường cần cập nhật cho loại da.",
+        "properties": {
+          "option_name": {
+            "type": "string"
+          },
+          "category_name": {
+            "type": "string"
+          },
+          "category_param": {
+            "type": "string"
+          }
+        }
+      },
+      "DisableFilterHskSkinTypeReqBody": {
+        "type": "object",
+        "required": [
+          "state"
+        ],
+        "properties": {
+          "state": {
+            "type": "string",
+            "description": "Trạng thái mới cho filter loại da.",
+            "enum": [
+              "INACTIVE",
+              "ACTIVE"
+            ],
+            "example": "INACTIVE"
+          }
+        }
+      },
+      "PaginatedFilterHskSkinTypeResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterHskSkinType"
             }
           },
           "pagination": {

--- a/backend/src/constants/messages.ts
+++ b/backend/src/constants/messages.ts
@@ -275,8 +275,20 @@ export const ADMIN_MESSAGES = {
   FILTER_PRODUCT_TYPE_NOT_FOUND: 'Filter product type not found',
   UPDATE_FILTER_PRODUCT_TYPE_SUCCESS: 'Update filter product type successfully',
   UPDATE_FILTER_PRODUCT_TYPE_STATE_SUCCESS: 'Filter product type update state successfully',
-  
-
+  //HSK Size
+  UPDATE_FILTER_SIZE_FAILED: 'Update filter size failed',
+  FILTER_SIZE_ID_IS_INVALID: 'Filter size ID is invalid',
+  FILTER_SIZE_NOT_FOUND: 'Filter size not found',
+  FILTER_SIZE_OPTION_NAME_IS_REQUIRED: 'Filter size option name is required',
+  FILTER_SIZE_OPTION_NAME_MUST_BE_STRING: 'Filter size option name must be a string',
+  FILTER_SIZE_CATEGORY_NAME_IS_REQUIRED: 'Filter size category name is required',
+  FILTER_SIZE_CATEGORY_NAME_MUST_BE_STRING: 'Filter size category name must be a string',
+  FILTER_SIZE_CATEGORY_PARAM_IS_REQUIRED: 'Filter size category param is required',
+  FILTER_SIZE_CATEGORY_PARAM_MUST_BE_STRING: 'Filter size category param must be a string',
+  FILTER_SIZE_STATE_MUST_BE_A_STRING: 'Filter size state must be a string',
+  CREATE_NEW_FILTER_SIZE_SUCCESS: 'Create new filter size successfully',
+  UPDATE_FILTER_SIZE_SUCCESS: 'Update filter size successfully',
+  UPDATE_FILTER_SIZE_STATE_SUCCESS: 'Filter size update state successfully'
 } as const
 
 export const CART_MESSAGES = {

--- a/backend/src/constants/messages.ts
+++ b/backend/src/constants/messages.ts
@@ -260,6 +260,22 @@ export const ADMIN_MESSAGES = {
   FILTER_INGREDIENT_NOT_FOUND: 'Filter ingredient not found',
   UPDATE_FILTER_INGREDIENT_SUCCESS: 'Update filter ingredient successfully',
   UPDATE_FILTER_INGREDIENT_STATE_SUCCESS: 'Filter ingredient update state successfully',
+  //product type
+  UPDATE_FILTER_PRODUCT_TYPE_FAILED: 'Update filter product type failed',
+  FILTER_PRODUCT_TYPE_OPTION_NAME_IS_REQUIRED: 'Filter product type option name is required',
+  FILTER_PRODUCT_TYPE_OPTION_NAME_MUST_BE_STRING: 'Filter product type option name must be a string',
+  FILTER_PRODUCT_TYPE_CATEGORY_NAME_IS_REQUIRED: 'Filter product type category name is required',
+  FILTER_PRODUCT_TYPE_CATEGORY_NAME_MUST_BE_STRING: 'Filter product type category name must be a string',
+  FILTER_PRODUCT_TYPE_CATEGORY_PARAM_IS_REQUIRED: 'Filter product type category param is required',
+  FILTER_PRODUCT_TYPE_CATEGORY_PARAM_MUST_BE_STRING: 'Filter product type category param must be a string',
+  FILTER_PRODUCT_TYPE_STATE_MUST_BE_A_STRING: 'Filter product type state must be a string',
+  FILTER_PRODUCT_TYPE_DESCRIPTION_MUST_BE_STRING: 'Filter product type description must be a string',
+  FILTER_PRODUCT_TYPE_ID_IS_INVALID: 'Filter product type ID is invalid',
+  CREATE_NEW_FILTER_PRODUCT_TYPE_SUCCESS: 'Create new filter product type successfully',
+  FILTER_PRODUCT_TYPE_NOT_FOUND: 'Filter product type not found',
+  UPDATE_FILTER_PRODUCT_TYPE_SUCCESS: 'Update filter product type successfully',
+  UPDATE_FILTER_PRODUCT_TYPE_STATE_SUCCESS: 'Filter product type update state successfully',
+  
 
 } as const
 

--- a/backend/src/constants/messages.ts
+++ b/backend/src/constants/messages.ts
@@ -288,7 +288,21 @@ export const ADMIN_MESSAGES = {
   FILTER_SIZE_STATE_MUST_BE_A_STRING: 'Filter size state must be a string',
   CREATE_NEW_FILTER_SIZE_SUCCESS: 'Create new filter size successfully',
   UPDATE_FILTER_SIZE_SUCCESS: 'Update filter size successfully',
-  UPDATE_FILTER_SIZE_STATE_SUCCESS: 'Filter size update state successfully'
+  UPDATE_FILTER_SIZE_STATE_SUCCESS: 'Filter size update state successfully',
+  //filter skin type
+  UPDATE_FILTER_SKIN_TYPE_FAILED: 'Update filter skin type failed',
+  FILTER_SKIN_TYPE_ID_IS_INVALID: 'Filter skin type ID is invalid',
+  FILTER_SKIN_TYPE_NOT_FOUND: 'Filter skin type not found',
+  FILTER_SKIN_TYPE_OPTION_NAME_IS_REQUIRED: 'Filter skin type option name is required',
+  FILTER_SKIN_TYPE_OPTION_NAME_MUST_BE_STRING: 'Filter skin type option name must be a string',
+  FILTER_SKIN_TYPE_CATEGORY_NAME_IS_REQUIRED: 'Filter skin type category name is required',
+  FILTER_SKIN_TYPE_CATEGORY_NAME_MUST_BE_STRING: 'Filter skin type category name must be a string',
+  FILTER_SKIN_TYPE_CATEGORY_PARAM_IS_REQUIRED: 'Filter skin type category param is required',
+  FILTER_SKIN_TYPE_CATEGORY_PARAM_MUST_BE_STRING: 'Filter skin type category param must be a string',
+  FILTER_SKIN_TYPE_STATE_MUST_BE_A_STRING: 'Filter skin type state must be a string',
+  CREATE_NEW_FILTER_SKIN_TYPE_SUCCESS: 'Create new filter skin type successfully',
+  UPDATE_FILTER_SKIN_TYPE_SUCCESS: 'Update filter skin type successfully',
+  UPDATE_FILTER_SKIN_TYPE_STATE_SUCCESS: 'Filter skin type update state successfully'
 } as const
 
 export const CART_MESSAGES = {

--- a/backend/src/controllers/filterHskProductType.controllers.ts
+++ b/backend/src/controllers/filterHskProductType.controllers.ts
@@ -1,0 +1,74 @@
+import { Request, Response, NextFunction } from 'express'
+import { ParamsDictionary } from 'express-serve-static-core'
+import { sendPaginatedResponse } from '~/utils/pagination.helper'
+import databaseService from '~/services/database.services'
+import {
+  createNewFilterHskProductTypeReqBody,
+  disableFilterHskProductTypeReqBody,
+  updateFilterHskProductTypeReqBody
+} from '~/models/requests/Admin.requests'
+import filterHskProductTypeService from '~/services/filterHskProductType.services'
+import { ObjectId } from 'mongodb'
+import { getLocalTime } from '~/utils/date'
+import { Filter } from 'mongodb'
+import FilterHskProductType from '~/models/schemas/FilterHskProductType.schema'
+import { ADMIN_MESSAGES } from '~/constants/messages'
+
+export const getAllFilterHskProductTypesController = async (req: Request, res: Response, next: NextFunction) => {
+  await sendPaginatedResponse(res, next, databaseService.filterHskProductType, req.query)
+}
+
+export const createNewFilterHskProductTypeController = async (
+  req: Request<ParamsDictionary, any, createNewFilterHskProductTypeReqBody>,
+  res: Response
+) => {
+  const result = await filterHskProductTypeService.createNewFilterProductType(req.body)
+  res.json({ message: ADMIN_MESSAGES.CREATE_NEW_FILTER_PRODUCT_TYPE_SUCCESS, result })
+}
+
+export const getFilterHskProductTypeByIdController = async (req: Request<{ _id: string }>, res: Response) => {
+  const { _id } = req.params
+  const result = await databaseService.filterHskProductType.findOne({ _id: new ObjectId(_id) })
+  if (!result) {
+    res.status(404).json({
+      message: ADMIN_MESSAGES.FILTER_PRODUCT_TYPE_NOT_FOUND
+    })
+  }
+  res.json({ data: result })
+}
+
+export const updateFilterHskProductTypeController = async (
+  req: Request<{ _id: string }, any, updateFilterHskProductTypeReqBody>,
+  res: Response
+) => {
+  const { _id } = req.params
+  const result = await filterHskProductTypeService.updateFilterProductType(_id, req.body)
+  res.json({ message: ADMIN_MESSAGES.UPDATE_FILTER_PRODUCT_TYPE_SUCCESS, result })
+}
+
+export const disableFilterHskProductTypeController = async (
+  req: Request<{ _id: string }, any, disableFilterHskProductTypeReqBody>,
+  res: Response
+) => {
+  const { _id } = req.params
+  const { state } = req.body
+  const currentDate = new Date()
+  const vietnamTimezoneOffset = 7 * 60
+  const localTime = new Date(currentDate.getTime() + vietnamTimezoneOffset * 60 * 1000)
+
+  const result = await databaseService.filterHskProductType.findOneAndUpdate(
+    { _id: new ObjectId(_id) },
+    { $set: { state, updated_at: localTime } },
+    { returnDocument: 'after' }
+  )
+  res.json({ message: ADMIN_MESSAGES.UPDATE_FILTER_PRODUCT_TYPE_STATE_SUCCESS, data: result })
+}
+
+export const searchFilterHskProductTypesController = async (req: Request, res: Response, next: NextFunction) => {
+  const { keyword } = req.query
+  const filter: Filter<FilterHskProductType> = {}
+  if (keyword) {
+    filter.option_name = { $regex: keyword as string, $options: 'i' }
+  }
+  await sendPaginatedResponse(res, next, databaseService.filterHskProductType, req.query, filter)
+}

--- a/backend/src/controllers/filterHskSize.controllers.ts
+++ b/backend/src/controllers/filterHskSize.controllers.ts
@@ -1,0 +1,74 @@
+import { Request, Response, NextFunction } from 'express'
+import { ParamsDictionary } from 'express-serve-static-core'
+import { sendPaginatedResponse } from '~/utils/pagination.helper'
+import databaseService from '~/services/database.services'
+import {
+  createNewFilterHskSizeReqBody,
+  disableFilterHskSizeReqBody,
+  updateFilterHskSizeReqBody
+} from '~/models/requests/Admin.requests'
+import filterHskSizeService from '~/services/filterHskSize.services'
+import { ObjectId } from 'mongodb'
+import { getLocalTime } from '~/utils/date'
+import { Filter } from 'mongodb'
+import FilterHskSize from '~/models/schemas/FilterHskSize.schema'
+import { ADMIN_MESSAGES } from '~/constants/messages'
+
+export const getAllFilterHskSizesController = async (req: Request, res: Response, next: NextFunction) => {
+  await sendPaginatedResponse(res, next, databaseService.filterHskSize, req.query)
+}
+
+export const createNewFilterHskSizeController = async (
+  req: Request<ParamsDictionary, any, createNewFilterHskSizeReqBody>,
+  res: Response
+) => {
+  const result = await filterHskSizeService.createNewFilterSize(req.body)
+  res.json({ message: ADMIN_MESSAGES.CREATE_NEW_FILTER_SIZE_SUCCESS, result })
+}
+
+export const getFilterHskSizeByIdController = async (req: Request<{ _id: string }>, res: Response) => {
+  const { _id } = req.params
+  const result = await databaseService.filterHskSize.findOne({ _id: new ObjectId(_id) })
+  if (!result) {
+    res.status(404).json({
+      message: ADMIN_MESSAGES.FILTER_SIZE_NOT_FOUND
+    })
+  }
+  res.json({ data: result })
+}
+
+export const updateFilterHskSizeController = async (
+  req: Request<{ _id: string }, any, updateFilterHskSizeReqBody>,
+  res: Response
+) => {
+  const { _id } = req.params
+  const result = await filterHskSizeService.updateFilterSize(_id, req.body)
+  res.json({ message: ADMIN_MESSAGES.UPDATE_FILTER_SIZE_SUCCESS, result })
+}
+
+export const disableFilterHskSizeController = async (
+  req: Request<{ _id: string }, any, disableFilterHskSizeReqBody>,
+  res: Response
+) => {
+  const { _id } = req.params
+  const { state } = req.body
+  const currentDate = new Date()
+  const vietnamTimezoneOffset = 7 * 60
+  const localTime = new Date(currentDate.getTime() + vietnamTimezoneOffset * 60 * 1000)
+
+  const result = await databaseService.filterHskSize.findOneAndUpdate(
+    { _id: new ObjectId(_id) },
+    { $set: { state, updated_at: localTime } },
+    { returnDocument: 'after' }
+  )
+  res.json({ message: ADMIN_MESSAGES.UPDATE_FILTER_SIZE_STATE_SUCCESS, data: result })
+}
+
+export const searchFilterHskSizesController = async (req: Request, res: Response, next: NextFunction) => {
+  const { keyword } = req.query
+  const filter: Filter<FilterHskSize> = {}
+  if (keyword) {
+    filter.option_name = { $regex: keyword as string, $options: 'i' }
+  }
+  await sendPaginatedResponse(res, next, databaseService.filterHskSize, req.query, filter)
+}

--- a/backend/src/controllers/filterHskSkinType.controllers.ts
+++ b/backend/src/controllers/filterHskSkinType.controllers.ts
@@ -1,0 +1,74 @@
+import { Request, Response, NextFunction } from 'express'
+import { ParamsDictionary } from 'express-serve-static-core'
+import { sendPaginatedResponse } from '~/utils/pagination.helper'
+import databaseService from '~/services/database.services'
+import {
+  createNewFilterHskSkinTypeReqBody,
+  disableFilterHskSkinTypeReqBody,
+  updateFilterHskSkinTypeReqBody
+} from '~/models/requests/Admin.requests'
+import filterHskSkinTypeService from '~/services/filterHskSkinType.services'
+import { ObjectId } from 'mongodb'
+import { getLocalTime } from '~/utils/date'
+import { Filter } from 'mongodb'
+import FilterHskSkinType from '~/models/schemas/FilterHskSkinType.schema'
+import { ADMIN_MESSAGES } from '~/constants/messages'
+
+export const getAllFilterHskSkinTypesController = async (req: Request, res: Response, next: NextFunction) => {
+  await sendPaginatedResponse(res, next, databaseService.filterHskSkinType, req.query)
+}
+
+export const createNewFilterHskSkinTypeController = async (
+  req: Request<ParamsDictionary, any, createNewFilterHskSkinTypeReqBody>,
+  res: Response
+) => {
+  const result = await filterHskSkinTypeService.createNewFilterSkinType(req.body)
+  res.json({ message: ADMIN_MESSAGES.CREATE_NEW_FILTER_SKIN_TYPE_SUCCESS, result })
+}
+
+export const getFilterHskSkinTypeByIdController = async (req: Request<{ _id: string }>, res: Response) => {
+  const { _id } = req.params
+  const result = await databaseService.filterHskSkinType.findOne({ _id: new ObjectId(_id) })
+  if (!result) {
+    res.status(404).json({
+      message: ADMIN_MESSAGES.FILTER_SKIN_TYPE_NOT_FOUND
+    })
+  }
+  res.json({ data: result })
+}
+
+export const updateFilterHskSkinTypeController = async (
+  req: Request<{ _id: string }, any, updateFilterHskSkinTypeReqBody>,
+  res: Response
+) => {
+  const { _id } = req.params
+  const result = await filterHskSkinTypeService.updateFilterSkinType(_id, req.body)
+  res.json({ message: ADMIN_MESSAGES.UPDATE_FILTER_SKIN_TYPE_SUCCESS, result })
+}
+
+export const disableFilterHskSkinTypeController = async (
+  req: Request<{ _id: string }, any, disableFilterHskSkinTypeReqBody>,
+  res: Response
+) => {
+  const { _id } = req.params
+  const { state } = req.body
+  const currentDate = new Date()
+  const vietnamTimezoneOffset = 7 * 60
+  const localTime = new Date(currentDate.getTime() + vietnamTimezoneOffset * 60 * 1000)
+
+  const result = await databaseService.filterHskSkinType.findOneAndUpdate(
+    { _id: new ObjectId(_id) },
+    { $set: { state, updated_at: localTime } },
+    { returnDocument: 'after' }
+  )
+  res.json({ message: ADMIN_MESSAGES.UPDATE_FILTER_SKIN_TYPE_STATE_SUCCESS, data: result })
+}
+
+export const searchFilterHskSkinTypesController = async (req: Request, res: Response, next: NextFunction) => {
+  const { keyword } = req.query
+  const filter: Filter<FilterHskSkinType> = {}
+  if (keyword) {
+    filter.option_name = { $regex: keyword as string, $options: 'i' }
+  }
+  await sendPaginatedResponse(res, next, databaseService.filterHskSkinType, req.query, filter)
+}

--- a/backend/src/docs/components/schemas/CreateFilterHskProductTypeReqBody.yaml
+++ b/backend/src/docs/components/schemas/CreateFilterHskProductTypeReqBody.yaml
@@ -1,0 +1,22 @@
+type: object
+required:
+  - option_name
+  - category_name
+  - category_param
+properties:
+  option_name:
+    type: string
+    example: 'Kem Chống Nắng'
+  description:
+    type: string
+    example: 'Sản phẩm bảo vệ da khỏi tia UV'
+  category_name:
+    type: string
+    example: 'Loại Sản Phẩm HSK'
+  category_param:
+    type: string
+    example: 'kem-chong-nang'
+  state:
+    type: string
+    enum: [INACTIVE, ACTIVE]
+    default: 'ACTIVE'

--- a/backend/src/docs/components/schemas/CreateFilterHskSizeReqBody.yaml
+++ b/backend/src/docs/components/schemas/CreateFilterHskSizeReqBody.yaml
@@ -1,0 +1,19 @@
+type: object
+required:
+  - option_name
+  - category_name
+  - category_param
+properties:
+  option_name:
+    type: string
+    example: '250ml'
+  category_name:
+    type: string
+    example: 'Kích Thước HSK'
+  category_param:
+    type: string
+    example: '250ml'
+  state:
+    type: string
+    enum: [INACTIVE, ACTIVE]
+    default: 'ACTIVE'

--- a/backend/src/docs/components/schemas/CreateFilterHskSkinTypeReqBody.yaml
+++ b/backend/src/docs/components/schemas/CreateFilterHskSkinTypeReqBody.yaml
@@ -1,0 +1,19 @@
+type: object
+required:
+  - option_name
+  - category_name
+  - category_param
+properties:
+  option_name:
+    type: string
+    example: 'Da Hỗn Hợp'
+  category_name:
+    type: string
+    example: 'Loại Da HSK'
+  category_param:
+    type: string
+    example: 'da-hon-hop'
+  state:
+    type: string
+    enum: [INACTIVE, ACTIVE]
+    default: 'ACTIVE'

--- a/backend/src/docs/components/schemas/DisableFilterHskProductTypeReqBody.yaml
+++ b/backend/src/docs/components/schemas/DisableFilterHskProductTypeReqBody.yaml
@@ -1,0 +1,9 @@
+type: object
+required:
+  - state
+properties:
+  state:
+    type: string
+    description: 'Trạng thái mới cho filter loại sản phẩm.'
+    enum: [INACTIVE, ACTIVE]
+    example: 'INACTIVE'

--- a/backend/src/docs/components/schemas/DisableFilterHskSizeReqBody.yaml
+++ b/backend/src/docs/components/schemas/DisableFilterHskSizeReqBody.yaml
@@ -1,0 +1,9 @@
+type: object
+required:
+  - state
+properties:
+  state:
+    type: string
+    description: 'Trạng thái mới cho filter kích thước.'
+    enum: [INACTIVE, ACTIVE]
+    example: 'INACTIVE'

--- a/backend/src/docs/components/schemas/DisableFilterHskSkinTypeReqBody.yaml
+++ b/backend/src/docs/components/schemas/DisableFilterHskSkinTypeReqBody.yaml
@@ -1,0 +1,9 @@
+type: object
+required:
+  - state
+properties:
+  state:
+    type: string
+    description: 'Trạng thái mới cho filter loại da.'
+    enum: [INACTIVE, ACTIVE]
+    example: 'INACTIVE'

--- a/backend/src/docs/components/schemas/FilterHskProductType.yaml
+++ b/backend/src/docs/components/schemas/FilterHskProductType.yaml
@@ -1,0 +1,27 @@
+type: object
+description: 'Đại diện cho một đối tượng filter Loại Sản Phẩm HSK.'
+properties:
+  _id:
+    type: string
+    format: mongoId
+  option_name:
+    type: string
+    example: 'Serum'
+  description:
+    type: string
+    example: 'Tinh chất đặc trị các vấn đề về da'
+  category_name:
+    type: string
+    example: 'Loại Sản Phẩm HSK'
+  category_param:
+    type: string
+    example: 'serum'
+  state:
+    type: string
+    enum: [INACTIVE, ACTIVE]
+  created_at:
+    type: string
+    format: date-time
+  updated_at:
+    type: string
+    format: date-time

--- a/backend/src/docs/components/schemas/FilterHskSize.yaml
+++ b/backend/src/docs/components/schemas/FilterHskSize.yaml
@@ -1,0 +1,24 @@
+type: object
+description: 'Đại diện cho một đối tượng filter Kích thước (Size).'
+properties:
+  _id:
+    type: string
+    format: mongoId
+  option_name:
+    type: string
+    example: '100ml'
+  category_name:
+    type: string
+    example: 'Kích Thước HSK'
+  category_param:
+    type: string
+    example: '100ml'
+  state:
+    type: string
+    enum: [INACTIVE, ACTIVE]
+  created_at:
+    type: string
+    format: date-time
+  updated_at:
+    type: string
+    format: date-time

--- a/backend/src/docs/components/schemas/FilterHskSkinType.yaml
+++ b/backend/src/docs/components/schemas/FilterHskSkinType.yaml
@@ -1,0 +1,24 @@
+type: object
+description: 'Đại diện cho một đối tượng filter Loại Da HSK.'
+properties:
+  _id:
+    type: string
+    format: mongoId
+  option_name:
+    type: string
+    example: 'Da Dầu'
+  category_name:
+    type: string
+    example: 'Loại Da HSK'
+  category_param:
+    type: string
+    example: 'da-dau'
+  state:
+    type: string
+    enum: [INACTIVE, ACTIVE]
+  created_at:
+    type: string
+    format: date-time
+  updated_at:
+    type: string
+    format: date-time

--- a/backend/src/docs/components/schemas/PaginatedFilterHskProductTypeResponse.yaml
+++ b/backend/src/docs/components/schemas/PaginatedFilterHskProductTypeResponse.yaml
@@ -1,0 +1,8 @@
+type: object
+properties:
+  data:
+    type: array
+    items:
+      $ref: './FilterHskProductType.yaml'
+  pagination:
+    $ref: './Pagination.yaml'

--- a/backend/src/docs/components/schemas/PaginatedFilterHskSizeResponse.yaml
+++ b/backend/src/docs/components/schemas/PaginatedFilterHskSizeResponse.yaml
@@ -1,0 +1,8 @@
+type: object
+properties:
+  data:
+    type: array
+    items:
+      $ref: './FilterHskSize.yaml'
+  pagination:
+    $ref: './Pagination.yaml'

--- a/backend/src/docs/components/schemas/PaginatedFilterHskSkinTypeResponse.yaml
+++ b/backend/src/docs/components/schemas/PaginatedFilterHskSkinTypeResponse.yaml
@@ -1,0 +1,8 @@
+type: object
+properties:
+  data:
+    type: array
+    items:
+      $ref: './FilterHskSkinType.yaml'
+  pagination:
+    $ref: './Pagination.yaml'

--- a/backend/src/docs/components/schemas/UpdateFilterHskProductTypeReqBody.yaml
+++ b/backend/src/docs/components/schemas/UpdateFilterHskProductTypeReqBody.yaml
@@ -1,0 +1,11 @@
+type: object
+description: 'Chỉ bao gồm các trường cần cập nhật cho loại sản phẩm.'
+properties:
+  option_name:
+    type: string
+  description:
+    type: string
+  category_name:
+    type: string
+  category_param:
+    type: string

--- a/backend/src/docs/components/schemas/UpdateFilterHskSizeReqBody.yaml
+++ b/backend/src/docs/components/schemas/UpdateFilterHskSizeReqBody.yaml
@@ -1,0 +1,9 @@
+type: object
+description: 'Chỉ bao gồm các trường cần cập nhật cho kích thước.'
+properties:
+  option_name:
+    type: string
+  category_name:
+    type: string
+  category_param:
+    type: string

--- a/backend/src/docs/components/schemas/UpdateFilterHskSkinTypeReqBody.yaml
+++ b/backend/src/docs/components/schemas/UpdateFilterHskSkinTypeReqBody.yaml
@@ -1,0 +1,9 @@
+type: object
+description: 'Chỉ bao gồm các trường cần cập nhật cho loại da.'
+properties:
+  option_name:
+    type: string
+  category_name:
+    type: string
+  category_param:
+    type: string

--- a/backend/src/docs/openapi.yaml
+++ b/backend/src/docs/openapi.yaml
@@ -205,6 +205,17 @@ components:
       $ref: './components/schemas/DisableFilterHskSizeReqBody.yaml'
     PaginatedFilterHskSizeResponse:
       $ref: './components/schemas/PaginatedFilterHskSizeResponse.yaml'
+    # FilterHskSkinType
+    FilterHskSkinType:
+      $ref: './components/schemas/FilterHskSkinType.yaml'
+    CreateFilterHskSkinTypeReqBody:
+      $ref: './components/schemas/CreateFilterHskSkinTypeReqBody.yaml'
+    UpdateFilterHskSkinTypeReqBody:
+      $ref: './components/schemas/UpdateFilterHskSkinTypeReqBody.yaml'
+    DisableFilterHskSkinTypeReqBody:
+      $ref: './components/schemas/DisableFilterHskSkinTypeReqBody.yaml'
+    PaginatedFilterHskSkinTypeResponse:
+      $ref: './components/schemas/PaginatedFilterHskSkinTypeResponse.yaml'
 
     # --- Response Schemas ---
     AuthSuccessResponse:

--- a/backend/src/docs/openapi.yaml
+++ b/backend/src/docs/openapi.yaml
@@ -194,6 +194,17 @@ components:
       $ref: './components/schemas/DisableFilterHskProductTypeReqBody.yaml'
     PaginatedFilterHskProductTypeResponse:
       $ref: './components/schemas/PaginatedFilterHskProductTypeResponse.yaml'
+    # FilterHskSize
+    FilterHskSize:
+      $ref: './components/schemas/FilterHskSize.yaml'
+    CreateFilterHskSizeReqBody:
+      $ref: './components/schemas/CreateFilterHskSizeReqBody.yaml'
+    UpdateFilterHskSizeReqBody:
+      $ref: './components/schemas/UpdateFilterHskSizeReqBody.yaml'
+    DisableFilterHskSizeReqBody:
+      $ref: './components/schemas/DisableFilterHskSizeReqBody.yaml'
+    PaginatedFilterHskSizeResponse:
+      $ref: './components/schemas/PaginatedFilterHskSizeResponse.yaml'
 
     # --- Response Schemas ---
     AuthSuccessResponse:

--- a/backend/src/docs/openapi.yaml
+++ b/backend/src/docs/openapi.yaml
@@ -34,21 +34,21 @@ tags:
   - name: Admin
     description: Operations for managing the system.
   - name: Admin - Filter Brand
-    description: "Quản lý bộ lọc Thương hiệu (filter_brand)"
+    description: 'Quản lý bộ lọc Thương hiệu (filter_brand)'
   - name: Admin - Filter Dac Tinh
-    description: "Quản lý bộ lọc Đặc tính (filter_dac_tinh)"
+    description: 'Quản lý bộ lọc Đặc tính (filter_dac_tinh)'
   - name: Admin - Filter Ingredient
-    description: "Quản lý bộ lọc Thành phần (filter_hsk_ingredient)"
+    description: 'Quản lý bộ lọc Thành phần (filter_hsk_ingredient)'
   - name: Admin - Filter Product Type
-    description: "Quản lý bộ lọc Loại sản phẩm (filter_hsk_product_type)"
+    description: 'Quản lý bộ lọc Loại sản phẩm (filter_hsk_product_type)'
   - name: Admin - Filter Size
-    description: "Quản lý bộ lọc Kích thước (filter_hsk_size)"
+    description: 'Quản lý bộ lọc Kích thước (filter_hsk_size)'
   - name: Admin - Filter Skin Type
-    description: "Quản lý bộ lọc Loại da (filter_hsk_skin_type)"
+    description: 'Quản lý bộ lọc Loại da (filter_hsk_skin_type)'
   - name: Admin - Filter Uses
-    description: "Quản lý bộ lọc Công dụng (filter_hsk_uses)"
+    description: 'Quản lý bộ lọc Công dụng (filter_hsk_uses)'
   - name: Admin - Filter Origin
-    description: "Quản lý bộ lọc Nguồn gốc (filter_origin)"
+    description: 'Quản lý bộ lọc Nguồn gốc (filter_origin)'
 paths:
   $ref: './paths/all-paths.yaml'
 
@@ -183,6 +183,17 @@ components:
       $ref: './components/schemas/DisableFilterHskIngredientReqBody.yaml'
     PaginatedFilterHskIngredientResponse:
       $ref: './components/schemas/PaginatedFilterHskIngredientResponse.yaml'
+    # FilterHskProductType
+    FilterHskProductType:
+      $ref: './components/schemas/FilterHskProductType.yaml'
+    CreateFilterHskProductTypeReqBody:
+      $ref: './components/schemas/CreateFilterHskProductTypeReqBody.yaml'
+    UpdateFilterHskProductTypeReqBody:
+      $ref: './components/schemas/UpdateFilterHskProductTypeReqBody.yaml'
+    DisableFilterHskProductTypeReqBody:
+      $ref: './components/schemas/DisableFilterHskProductTypeReqBody.yaml'
+    PaginatedFilterHskProductTypeResponse:
+      $ref: './components/schemas/PaginatedFilterHskProductTypeResponse.yaml'
 
     # --- Response Schemas ---
     AuthSuccessResponse:

--- a/backend/src/docs/paths/all-paths.yaml
+++ b/backend/src/docs/paths/all-paths.yaml
@@ -2714,3 +2714,155 @@
               $ref: '../components/schemas/PaginatedFilterHskSizeResponse.yaml'
       '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
       '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+
+/admin/manage-filters/create-new-filter-hsk-skin-type:
+  post:
+    tags: [Admin - Filter Skin Type]
+    summary: (Admin) Create a New HSK Skin Type Filter
+    security:
+      - BearerAuth: []
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/CreateFilterHskSkinTypeReqBody.yaml'
+    responses:
+      '200':
+        description: Filter loại da được tạo thành công.
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/MessageResponse.yaml'
+      '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '422': { $ref: '../components/schemas/ErrorValidationResponse.yaml' }
+
+/admin/manage-filters/get-all-filter-hsk-skin-types:
+  get:
+    tags: [Admin - Filter Skin Type]
+    summary: (Admin) Get All HSK Skin Type Filters
+    security:
+      - BearerAuth: []
+    parameters:
+      - $ref: '../openapi.yaml#/components/parameters/PageQuery'
+      - $ref: '../openapi.yaml#/components/parameters/LimitQuery'
+    responses:
+      '200':
+        description: Trả về danh sách các filter loại da.
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/PaginatedFilterHskSkinTypeResponse.yaml'
+      '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+
+/admin/manage-filters/get-filter-hsk-skin-type-detail/{_id}:
+  get:
+    tags: [Admin - Filter Skin Type]
+    summary: (Admin) Get HSK Skin Type Filter by ID
+    security:
+      - BearerAuth: []
+    parameters:
+      - name: _id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: mongoId
+    responses:
+      '200':
+        description: Chi tiết filter loại da.
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/FilterHskSkinType.yaml'
+      '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '404': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+
+/admin/manage-filters/update-filter-hsk-skin-type/{_id}:
+  put:
+    tags: [Admin - Filter Skin Type]
+    summary: (Admin) Update an HSK Skin Type Filter
+    security:
+      - BearerAuth: []
+    parameters:
+      - name: _id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: mongoId
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/UpdateFilterHskSkinTypeReqBody.yaml'
+    responses:
+      '200':
+        description: Filter loại da được cập nhật thành công.
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/FilterHskSkinType.yaml'
+      '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '404': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '422': { $ref: '../components/schemas/ErrorValidationResponse.yaml' }
+
+/admin/manage-filters/update-filter-hsk-skin-type-state/{_id}:
+  put:
+    tags: [Admin - Filter Skin Type]
+    summary: (Admin) Update HSK Skin Type Filter State
+    security:
+      - BearerAuth: []
+    parameters:
+      - name: _id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: mongoId
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/DisableFilterHskSkinTypeReqBody.yaml'
+    responses:
+      '200':
+        description: Trạng thái filter loại da được cập nhật thành công.
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/FilterHskSkinType.yaml'
+      '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '404': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '422': { $ref: '../components/schemas/ErrorValidationResponse.yaml' }
+
+/admin/manage-filters/search-filter-hsk-skin-type:
+  get:
+    tags: [Admin - Filter Skin Type]
+    summary: (Admin) Search HSK Skin Type Filters by Name
+    security:
+      - BearerAuth: []
+    parameters:
+      - $ref: '../openapi.yaml#/components/parameters/PageQuery'
+      - $ref: '../openapi.yaml#/components/parameters/LimitQuery'
+      - name: keyword
+        in: query
+        description: Từ khóa tìm kiếm trong tên loại da.
+        schema:
+          type: string
+    responses:
+      '200':
+        description: Trả về danh sách các filter loại da phù hợp.
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/PaginatedFilterHskSkinTypeResponse.yaml'
+      '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }

--- a/backend/src/docs/paths/all-paths.yaml
+++ b/backend/src/docs/paths/all-paths.yaml
@@ -2562,3 +2562,155 @@
               $ref: '../components/schemas/PaginatedFilterHskProductTypeResponse.yaml'
       '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
       '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+
+/admin/manage-filters/create-new-filter-hsk-size:
+  post:
+    tags: [Admin - Filter Size]
+    summary: (Admin) Create a New HSK Size Filter
+    security:
+      - BearerAuth: []
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/CreateFilterHskSizeReqBody.yaml'
+    responses:
+      '200':
+        description: Filter kích thước được tạo thành công.
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/MessageResponse.yaml'
+      '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '422': { $ref: '../components/schemas/ErrorValidationResponse.yaml' }
+
+/admin/manage-filters/get-all-filter-hsk-sizes:
+  get:
+    tags: [Admin - Filter Size]
+    summary: (Admin) Get All HSK Size Filters
+    security:
+      - BearerAuth: []
+    parameters:
+      - $ref: '../openapi.yaml#/components/parameters/PageQuery'
+      - $ref: '../openapi.yaml#/components/parameters/LimitQuery'
+    responses:
+      '200':
+        description: Trả về danh sách các filter kích thước.
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/PaginatedFilterHskSizeResponse.yaml'
+      '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+
+/admin/manage-filters/get-filter-hsk-size-detail/{_id}:
+  get:
+    tags: [Admin - Filter Size]
+    summary: (Admin) Get HSK Size Filter by ID
+    security:
+      - BearerAuth: []
+    parameters:
+      - name: _id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: mongoId
+    responses:
+      '200':
+        description: Chi tiết filter kích thước.
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/FilterHskSize.yaml'
+      '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '404': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+
+/admin/manage-filters/update-filter-hsk-size/{_id}:
+  put:
+    tags: [Admin - Filter Size]
+    summary: (Admin) Update an HSK Size Filter
+    security:
+      - BearerAuth: []
+    parameters:
+      - name: _id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: mongoId
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/UpdateFilterHskSizeReqBody.yaml'
+    responses:
+      '200':
+        description: Filter kích thước được cập nhật thành công.
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/FilterHskSize.yaml'
+      '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '404': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '422': { $ref: '../components/schemas/ErrorValidationResponse.yaml' }
+
+/admin/manage-filters/update-filter-hsk-size-state/{_id}:
+  put:
+    tags: [Admin - Filter Size]
+    summary: (Admin) Update HSK Size Filter State
+    security:
+      - BearerAuth: []
+    parameters:
+      - name: _id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: mongoId
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/DisableFilterHskSizeReqBody.yaml'
+    responses:
+      '200':
+        description: Trạng thái filter kích thước được cập nhật thành công.
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/FilterHskSize.yaml'
+      '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '404': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '422': { $ref: '../components/schemas/ErrorValidationResponse.yaml' }
+
+/admin/manage-filters/search-filter-hsk-size:
+  get:
+    tags: [Admin - Filter Size]
+    summary: (Admin) Search HSK Size Filters by Name
+    security:
+      - BearerAuth: []
+    parameters:
+      - $ref: '../openapi.yaml#/components/parameters/PageQuery'
+      - $ref: '../openapi.yaml#/components/parameters/LimitQuery'
+      - name: keyword
+        in: query
+        description: Từ khóa tìm kiếm trong tên kích thước.
+        schema:
+          type: string
+    responses:
+      '200':
+        description: Trả về danh sách các filter kích thước phù hợp.
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/PaginatedFilterHskSizeResponse.yaml'
+      '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }

--- a/backend/src/docs/paths/all-paths.yaml
+++ b/backend/src/docs/paths/all-paths.yaml
@@ -2410,3 +2410,155 @@
         $ref: '../components/schemas/ErrorStatusResponse.yaml'
       '403':
         $ref: '../components/schemas/ErrorStatusResponse.yaml'
+
+/admin/manage-filters/create-new-filter-hsk-product-type:
+  post:
+    tags: [Admin - Filter Product Type]
+    summary: (Admin) Create a New HSK Product Type Filter
+    security:
+      - BearerAuth: []
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/CreateFilterHskProductTypeReqBody.yaml'
+    responses:
+      '200':
+        description: Filter loại sản phẩm được tạo thành công.
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/MessageResponse.yaml'
+      '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '422': { $ref: '../components/schemas/ErrorValidationResponse.yaml' }
+
+/admin/manage-filters/get-all-filter-hsk-product-types:
+  get:
+    tags: [Admin - Filter Product Type]
+    summary: (Admin) Get All HSK Product Type Filters
+    security:
+      - BearerAuth: []
+    parameters:
+      - $ref: '../openapi.yaml#/components/parameters/PageQuery'
+      - $ref: '../openapi.yaml#/components/parameters/LimitQuery'
+    responses:
+      '200':
+        description: Trả về danh sách các filter loại sản phẩm.
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/PaginatedFilterHskProductTypeResponse.yaml'
+      '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+
+/admin/manage-filters/get-filter-hsk-product-type-detail/{_id}:
+  get:
+    tags: [Admin - Filter Product Type]
+    summary: (Admin) Get HSK Product Type Filter by ID
+    security:
+      - BearerAuth: []
+    parameters:
+      - name: _id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: mongoId
+    responses:
+      '200':
+        description: Chi tiết filter loại sản phẩm.
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/FilterHskProductType.yaml'
+      '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '404': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+
+/admin/manage-filters/update-filter-hsk-product-type/{_id}:
+  put:
+    tags: [Admin - Filter Product Type]
+    summary: (Admin) Update an HSK Product Type Filter
+    security:
+      - BearerAuth: []
+    parameters:
+      - name: _id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: mongoId
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/UpdateFilterHskProductTypeReqBody.yaml'
+    responses:
+      '200':
+        description: Filter loại sản phẩm được cập nhật thành công.
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/FilterHskProductType.yaml'
+      '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '404': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '422': { $ref: '../components/schemas/ErrorValidationResponse.yaml' }
+
+/admin/manage-filters/update-filter-hsk-product-type-state/{_id}:
+  put:
+    tags: [Admin - Filter Product Type]
+    summary: (Admin) Update HSK Product Type Filter State
+    security:
+      - BearerAuth: []
+    parameters:
+      - name: _id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: mongoId
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/DisableFilterHskProductTypeReqBody.yaml'
+    responses:
+      '200':
+        description: Trạng thái filter loại sản phẩm được cập nhật thành công.
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/FilterHskProductType.yaml'
+      '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '404': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '422': { $ref: '../components/schemas/ErrorValidationResponse.yaml' }
+
+/admin/manage-filters/search-filter-hsk-product-type:
+  get:
+    tags: [Admin - Filter Product Type]
+    summary: (Admin) Search HSK Product Type Filters by Name
+    security:
+      - BearerAuth: []
+    parameters:
+      - $ref: '../openapi.yaml#/components/parameters/PageQuery'
+      - $ref: '../openapi.yaml#/components/parameters/LimitQuery'
+      - name: keyword
+        in: query
+        description: Từ khóa tìm kiếm trong tên loại sản phẩm.
+        schema:
+          type: string
+    responses:
+      '200':
+        description: Trả về danh sách các filter loại sản phẩm phù hợp.
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/PaginatedFilterHskProductTypeResponse.yaml'
+      '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }

--- a/backend/src/middlewares/filterHskProductType.middlewares.ts
+++ b/backend/src/middlewares/filterHskProductType.middlewares.ts
@@ -1,0 +1,107 @@
+import { validate } from '~/utils/validation'
+import { checkSchema } from 'express-validator'
+import { GenericFilterState } from '~/constants/enums'
+import { ObjectId } from 'mongodb'
+import databaseService from '~/services/database.services'
+import { ErrorWithStatus } from '~/models/Errors'
+import HTTP_STATUS from '~/constants/httpStatus'
+import { ADMIN_MESSAGES } from '~/constants/messages'
+
+export const createNewFilterHskProductTypeValidator = validate(
+  checkSchema(
+    {
+      option_name: {
+        notEmpty: { errorMessage: ADMIN_MESSAGES.FILTER_PRODUCT_TYPE_OPTION_NAME_IS_REQUIRED },
+        isString: { errorMessage: ADMIN_MESSAGES.FILTER_PRODUCT_TYPE_OPTION_NAME_MUST_BE_STRING },
+        trim: true
+      },
+      description: {
+        optional: true,
+        isString: { errorMessage: ADMIN_MESSAGES.FILTER_PRODUCT_TYPE_DESCRIPTION_MUST_BE_STRING },
+        trim: true
+      },
+      category_name: {
+        notEmpty: { errorMessage: ADMIN_MESSAGES.FILTER_PRODUCT_TYPE_CATEGORY_NAME_IS_REQUIRED },
+        isString: { errorMessage: ADMIN_MESSAGES.FILTER_PRODUCT_TYPE_CATEGORY_NAME_MUST_BE_STRING },
+        trim: true
+      },
+      category_param: {
+        notEmpty: { errorMessage: ADMIN_MESSAGES.FILTER_PRODUCT_TYPE_CATEGORY_PARAM_IS_REQUIRED },
+        isString: { errorMessage: ADMIN_MESSAGES.FILTER_PRODUCT_TYPE_CATEGORY_PARAM_MUST_BE_STRING },
+        trim: true
+      },
+      state: {
+        optional: true,
+        isString: { errorMessage: ADMIN_MESSAGES.FILTER_PRODUCT_TYPE_STATE_MUST_BE_A_STRING },
+        isIn: {
+          options: [Object.values(GenericFilterState)],
+          errorMessage: `Trạng thái phải là một trong các giá trị: ${Object.values(GenericFilterState).join(', ')}`
+        }
+      }
+    },
+    ['body']
+  )
+)
+
+export const updateFilterHskProductTypeValidator = validate(
+  checkSchema({
+    _id: { in: ['params'], isMongoId: { errorMessage: 'ID không hợp lệ' } },
+    option_name: {
+      optional: true,
+      isString: { errorMessage: ADMIN_MESSAGES.FILTER_PRODUCT_TYPE_OPTION_NAME_MUST_BE_STRING },
+      trim: true
+    },
+    description: {
+      optional: true,
+      isString: { errorMessage: ADMIN_MESSAGES.FILTER_PRODUCT_TYPE_DESCRIPTION_MUST_BE_STRING },
+      trim: true
+    },
+    category_name: {
+      optional: true,
+      isString: { errorMessage: ADMIN_MESSAGES.FILTER_PRODUCT_TYPE_CATEGORY_NAME_MUST_BE_STRING },
+      trim: true
+    },
+    category_param: {
+      optional: true,
+      isString: { errorMessage: ADMIN_MESSAGES.FILTER_PRODUCT_TYPE_CATEGORY_PARAM_MUST_BE_STRING },
+      trim: true
+    }
+  })
+)
+
+export const disableFilterHskProductTypeValidator = validate(
+  checkSchema({
+    _id: { in: ['params'], isMongoId: { errorMessage: ADMIN_MESSAGES.FILTER_PRODUCT_TYPE_ID_IS_INVALID } },
+    state: {
+      in: ['body'],
+      isIn: {
+        options: [Object.values(GenericFilterState)],
+        errorMessage: `Trạng thái phải là một trong các giá trị: ${Object.values(GenericFilterState).join(', ')}`
+      }
+    }
+  })
+)
+
+export const getFilterHskProductTypeByIdValidator = validate(
+  checkSchema(
+    {
+      _id: {
+        in: ['params'],
+        isMongoId: { errorMessage: ADMIN_MESSAGES.FILTER_PRODUCT_TYPE_ID_IS_INVALID },
+        custom: {
+          options: async (value) => {
+            const productType = await databaseService.filterHskProductType.findOne({ _id: new ObjectId(value) })
+            if (!productType) {
+              throw new ErrorWithStatus({
+                message: ADMIN_MESSAGES.FILTER_PRODUCT_TYPE_ID_IS_INVALID,
+                status: HTTP_STATUS.NOT_FOUND
+              })
+            }
+            return true
+          }
+        }
+      }
+    },
+    ['params']
+  )
+)

--- a/backend/src/middlewares/filterHskSize.middlewares.ts
+++ b/backend/src/middlewares/filterHskSize.middlewares.ts
@@ -1,0 +1,97 @@
+import { validate } from '~/utils/validation'
+import { checkSchema } from 'express-validator'
+import { GenericFilterState } from '~/constants/enums'
+import { ObjectId } from 'mongodb'
+import databaseService from '~/services/database.services'
+import { ErrorWithStatus } from '~/models/Errors'
+import HTTP_STATUS from '~/constants/httpStatus'
+import { ADMIN_MESSAGES } from '~/constants/messages'
+
+export const createNewFilterHskSizeValidator = validate(
+  checkSchema(
+    {
+      option_name: {
+        notEmpty: { errorMessage: ADMIN_MESSAGES.FILTER_SIZE_OPTION_NAME_IS_REQUIRED },
+        isString: { errorMessage: ADMIN_MESSAGES.FILTER_SIZE_OPTION_NAME_MUST_BE_STRING },
+        trim: true
+      },
+      category_name: {
+        notEmpty: { errorMessage: ADMIN_MESSAGES.FILTER_SIZE_CATEGORY_NAME_IS_REQUIRED },
+        isString: { errorMessage: ADMIN_MESSAGES.FILTER_SIZE_CATEGORY_NAME_MUST_BE_STRING },
+        trim: true
+      },
+      category_param: {
+        notEmpty: { errorMessage: ADMIN_MESSAGES.FILTER_SIZE_CATEGORY_PARAM_IS_REQUIRED },
+        isString: { errorMessage: ADMIN_MESSAGES.FILTER_SIZE_CATEGORY_PARAM_MUST_BE_STRING },
+        trim: true
+      },
+      state: {
+        optional: true,
+        isString: { errorMessage: ADMIN_MESSAGES.FILTER_SIZE_STATE_MUST_BE_A_STRING },
+        isIn: {
+          options: [Object.values(GenericFilterState)],
+          errorMessage: `Trạng thái phải là một trong các giá trị: ${Object.values(GenericFilterState).join(', ')}`
+        }
+      }
+    },
+    ['body']
+  )
+)
+
+export const updateFilterHskSizeValidator = validate(
+  checkSchema({
+    _id: { in: ['params'], isMongoId: { errorMessage: ADMIN_MESSAGES.FILTER_SIZE_ID_IS_INVALID } },
+    option_name: {
+      optional: true,
+      isString: { errorMessage: ADMIN_MESSAGES.FILTER_SIZE_OPTION_NAME_MUST_BE_STRING },
+      trim: true
+    },
+    category_name: {
+      optional: true,
+      isString: { errorMessage: ADMIN_MESSAGES.FILTER_SIZE_CATEGORY_NAME_MUST_BE_STRING },
+      trim: true
+    },
+    category_param: {
+      optional: true,
+      isString: { errorMessage: ADMIN_MESSAGES.FILTER_SIZE_CATEGORY_PARAM_MUST_BE_STRING },
+      trim: true
+    }
+  })
+)
+
+export const disableFilterHskSizeValidator = validate(
+  checkSchema({
+    _id: { in: ['params'], isMongoId: { errorMessage: ADMIN_MESSAGES.FILTER_SIZE_ID_IS_INVALID } },
+    state: {
+      in: ['body'],
+      isIn: {
+        options: [Object.values(GenericFilterState)],
+        errorMessage: `Trạng thái phải là một trong các giá trị: ${Object.values(GenericFilterState).join(', ')}`
+      }
+    }
+  })
+)
+
+export const getFilterHskSizeByIdValidator = validate(
+  checkSchema(
+    {
+      _id: {
+        in: ['params'],
+        isMongoId: { errorMessage: ADMIN_MESSAGES.FILTER_SIZE_ID_IS_INVALID },
+        custom: {
+          options: async (value) => {
+            const size = await databaseService.filterHskSize.findOne({ _id: new ObjectId(value) })
+            if (!size) {
+              throw new ErrorWithStatus({
+                message: ADMIN_MESSAGES.FILTER_SIZE_NOT_FOUND,
+                status: HTTP_STATUS.NOT_FOUND
+              })
+            }
+            return true
+          }
+        }
+      }
+    },
+    ['params']
+  )
+)

--- a/backend/src/middlewares/filterHskSkinType.middlewares.ts
+++ b/backend/src/middlewares/filterHskSkinType.middlewares.ts
@@ -1,0 +1,97 @@
+import { validate } from '~/utils/validation'
+import { checkSchema } from 'express-validator'
+import { GenericFilterState } from '~/constants/enums'
+import { ObjectId } from 'mongodb'
+import databaseService from '~/services/database.services'
+import { ErrorWithStatus } from '~/models/Errors'
+import HTTP_STATUS from '~/constants/httpStatus'
+import { ADMIN_MESSAGES } from '~/constants/messages'
+
+export const createNewFilterHskSkinTypeValidator = validate(
+  checkSchema(
+    {
+      option_name: {
+        notEmpty: { errorMessage: ADMIN_MESSAGES.FILTER_SKIN_TYPE_OPTION_NAME_IS_REQUIRED },
+        isString: { errorMessage: ADMIN_MESSAGES.FILTER_SKIN_TYPE_OPTION_NAME_MUST_BE_STRING },
+        trim: true
+      },
+      category_name: {
+        notEmpty: { errorMessage: ADMIN_MESSAGES.FILTER_SKIN_TYPE_CATEGORY_NAME_IS_REQUIRED },
+        isString: { errorMessage: ADMIN_MESSAGES.FILTER_SKIN_TYPE_CATEGORY_NAME_MUST_BE_STRING },
+        trim: true
+      },
+      category_param: {
+        notEmpty: { errorMessage: ADMIN_MESSAGES.FILTER_SKIN_TYPE_CATEGORY_PARAM_IS_REQUIRED },
+        isString: { errorMessage: ADMIN_MESSAGES.FILTER_SKIN_TYPE_CATEGORY_PARAM_MUST_BE_STRING },
+        trim: true
+      },
+      state: {
+        optional: true,
+        isString: { errorMessage: ADMIN_MESSAGES.FILTER_SKIN_TYPE_STATE_MUST_BE_A_STRING },
+        isIn: {
+          options: [Object.values(GenericFilterState)],
+          errorMessage: `Trạng thái phải là một trong các giá trị: ${Object.values(GenericFilterState).join(', ')}`
+        }
+      }
+    },
+    ['body']
+  )
+)
+
+export const updateFilterHskSkinTypeValidator = validate(
+  checkSchema({
+    _id: { in: ['params'], isMongoId: { errorMessage: ADMIN_MESSAGES.FILTER_SKIN_TYPE_ID_IS_INVALID } },
+    option_name: {
+      optional: true,
+      isString: { errorMessage: ADMIN_MESSAGES.FILTER_SKIN_TYPE_OPTION_NAME_MUST_BE_STRING },
+      trim: true
+    },
+    category_name: {
+      optional: true,
+      isString: { errorMessage: ADMIN_MESSAGES.FILTER_SKIN_TYPE_CATEGORY_NAME_MUST_BE_STRING },
+      trim: true
+    },
+    category_param: {
+      optional: true,
+      isString: { errorMessage: ADMIN_MESSAGES.FILTER_SKIN_TYPE_CATEGORY_PARAM_MUST_BE_STRING },
+      trim: true
+    }
+  })
+)
+
+export const disableFilterHskSkinTypeValidator = validate(
+  checkSchema({
+    _id: { in: ['params'], isMongoId: { errorMessage: ADMIN_MESSAGES.FILTER_SKIN_TYPE_ID_IS_INVALID } },
+    state: {
+      in: ['body'],
+      isIn: {
+        options: [Object.values(GenericFilterState)],
+        errorMessage: `Trạng thái phải là một trong các giá trị: ${Object.values(GenericFilterState).join(', ')}`
+      }
+    }
+  })
+)
+
+export const getFilterHskSkinTypeByIdValidator = validate(
+  checkSchema(
+    {
+      _id: {
+        in: ['params'],
+        isMongoId: { errorMessage: ADMIN_MESSAGES.FILTER_SKIN_TYPE_ID_IS_INVALID },
+        custom: {
+          options: async (value) => {
+            const skinType = await databaseService.filterHskSkinType.findOne({ _id: new ObjectId(value) })
+            if (!skinType) {
+              throw new ErrorWithStatus({
+                message: ADMIN_MESSAGES.FILTER_SKIN_TYPE_NOT_FOUND,
+                status: HTTP_STATUS.NOT_FOUND
+              })
+            }
+            return true
+          }
+        }
+      }
+    },
+    ['params']
+  )
+)

--- a/backend/src/models/requests/Admin.requests.ts
+++ b/backend/src/models/requests/Admin.requests.ts
@@ -95,3 +95,20 @@ export interface updateFilterHskSizeReqBody {
 export interface disableFilterHskSizeReqBody {
   state: GenericFilterState
 }
+
+export interface createNewFilterHskSkinTypeReqBody {
+  option_name: string
+  category_name: string
+  category_param: string
+  state?: GenericFilterState
+}
+
+export interface updateFilterHskSkinTypeReqBody {
+  option_name?: string
+  category_name?: string
+  category_param?: string
+}
+
+export interface disableFilterHskSkinTypeReqBody {
+  state: GenericFilterState
+}

--- a/backend/src/models/requests/Admin.requests.ts
+++ b/backend/src/models/requests/Admin.requests.ts
@@ -59,3 +59,22 @@ export interface updateFilterHskIngredientReqBody {
 export interface disableFilterHskIngredientReqBody {
   state: GenericFilterState
 }
+
+export interface createNewFilterHskProductTypeReqBody {
+  option_name: string
+  description?: string
+  category_name: string
+  category_param: string
+  state?: GenericFilterState
+}
+
+export interface updateFilterHskProductTypeReqBody {
+  option_name?: string
+  description?: string
+  category_name?: string
+  category_param?: string
+}
+
+export interface disableFilterHskProductTypeReqBody {
+  state: GenericFilterState
+}

--- a/backend/src/models/requests/Admin.requests.ts
+++ b/backend/src/models/requests/Admin.requests.ts
@@ -78,3 +78,20 @@ export interface updateFilterHskProductTypeReqBody {
 export interface disableFilterHskProductTypeReqBody {
   state: GenericFilterState
 }
+
+export interface createNewFilterHskSizeReqBody {
+  option_name: string
+  category_name: string
+  category_param: string
+  state?: GenericFilterState
+}
+
+export interface updateFilterHskSizeReqBody {
+  option_name?: string
+  category_name?: string
+  category_param?: string
+}
+
+export interface disableFilterHskSizeReqBody {
+  state: GenericFilterState
+}

--- a/backend/src/models/schemas/FilterHskProductType.schema.ts
+++ b/backend/src/models/schemas/FilterHskProductType.schema.ts
@@ -1,4 +1,5 @@
 import { ObjectId } from 'mongodb'
+import { GenericFilterState } from '~/constants/enums'
 
 interface FilterHskProductTypeType {
   _id?: ObjectId
@@ -6,6 +7,9 @@ interface FilterHskProductTypeType {
   description?: string
   category_name?: string
   category_param?: string
+  state?: GenericFilterState
+  created_at?: Date
+  updated_at?: Date
 }
 
 export default class FilterHskProductType {
@@ -14,12 +18,22 @@ export default class FilterHskProductType {
   description?: string
   category_name?: string
   category_param?: string
+  state?: GenericFilterState
+  created_at?: Date
+  updated_at?: Date
 
   constructor(filterHskProductType: FilterHskProductTypeType) {
+    const currentDate = new Date()
+    const vietnamTimezoneOffset = 7 * 60
+    const localTime = new Date(currentDate.getTime() + vietnamTimezoneOffset * 60 * 1000)
+
     this._id = filterHskProductType._id || new ObjectId()
     this.option_name = filterHskProductType.option_name || ''
     this.description = filterHskProductType.description || ''
     this.category_name = filterHskProductType.category_name || ''
     this.category_param = filterHskProductType.category_param || ''
+    this.state = filterHskProductType.state || GenericFilterState.ACTIVE
+    this.created_at = filterHskProductType.created_at || localTime
+    this.updated_at = filterHskProductType.updated_at || localTime
   }
 }

--- a/backend/src/models/schemas/FilterHskSize.schema.ts
+++ b/backend/src/models/schemas/FilterHskSize.schema.ts
@@ -1,10 +1,14 @@
 import { ObjectId } from 'mongodb'
+import { GenericFilterState } from '~/constants/enums'
 
 interface FilterHskSizeType {
   _id?: ObjectId
   option_name?: string
   category_name?: string
   category_param?: string
+  state?: GenericFilterState
+  created_at?: Date
+  updated_at?: Date
 }
 
 export default class FilterHskSize {
@@ -12,11 +16,21 @@ export default class FilterHskSize {
   option_name?: string
   category_name?: string
   category_param?: string
+  state?: GenericFilterState
+  created_at?: Date
+  updated_at?: Date
 
   constructor(filterHskSize: FilterHskSizeType) {
+    const currentDate = new Date()
+    const vietnamTimezoneOffset = 7 * 60
+    const localTime = new Date(currentDate.getTime() + vietnamTimezoneOffset * 60 * 1000)
+
     this._id = filterHskSize._id || new ObjectId()
     this.option_name = filterHskSize.option_name || ''
     this.category_name = filterHskSize.category_name || ''
     this.category_param = filterHskSize.category_param || ''
+    this.state = filterHskSize.state || GenericFilterState.ACTIVE
+    this.created_at = filterHskSize.created_at || localTime
+    this.updated_at = filterHskSize.updated_at || localTime
   }
 }

--- a/backend/src/models/schemas/FilterHskSkinType.schema.ts
+++ b/backend/src/models/schemas/FilterHskSkinType.schema.ts
@@ -1,10 +1,14 @@
 import { ObjectId } from 'mongodb'
+import { GenericFilterState } from '~/constants/enums'
 
 interface FilterHskSkinTypeType {
   _id?: ObjectId
   option_name?: string
   category_name?: string
   category_param?: string
+  state?: GenericFilterState
+  created_at?: Date
+  updated_at?: Date
 }
 
 export default class FilterHskSkinType {
@@ -12,11 +16,21 @@ export default class FilterHskSkinType {
   option_name?: string
   category_name?: string
   category_param?: string
+  state?: GenericFilterState
+  created_at?: Date
+  updated_at?: Date
 
   constructor(filterHskSkinType: FilterHskSkinTypeType) {
+    const currentDate = new Date()
+    const vietnamTimezoneOffset = 7 * 60
+    const localTime = new Date(currentDate.getTime() + vietnamTimezoneOffset * 60 * 1000)
+
     this._id = filterHskSkinType._id || new ObjectId()
     this.option_name = filterHskSkinType.option_name || ''
     this.category_name = filterHskSkinType.category_name || ''
     this.category_param = filterHskSkinType.category_param || ''
+    this.state = filterHskSkinType.state || GenericFilterState.ACTIVE
+    this.created_at = filterHskSkinType.created_at || localTime
+    this.updated_at = filterHskSkinType.updated_at || localTime
   }
 }

--- a/backend/src/routes/admin.routes.ts
+++ b/backend/src/routes/admin.routes.ts
@@ -43,7 +43,7 @@ import {
   searchFilterBrandsController,
   updateFilterBrandController
 } from '~/controllers/filterBrand.controllers'
-import { disableFilterBrandReqBody, disableFilterDacTinhReqBody, disableFilterHskIngredientReqBody, disableFilterHskProductTypeReqBody, updateFilterBrandReqBody, updateFilterDacTinhReqBody, updateFilterHskIngredientReqBody, updateFilterHskProductTypeReqBody } from '~/models/requests/Admin.requests'
+import { disableFilterBrandReqBody, disableFilterDacTinhReqBody, disableFilterHskIngredientReqBody, disableFilterHskProductTypeReqBody, disableFilterHskSizeReqBody, updateFilterBrandReqBody, updateFilterDacTinhReqBody, updateFilterHskIngredientReqBody, updateFilterHskProductTypeReqBody, updateFilterHskSizeReqBody } from '~/models/requests/Admin.requests'
 import {
   disableFilterBrandValidator,
   getFilterBrandByIdValidator,
@@ -55,6 +55,8 @@ import { createNewFilterHskIngredientController, disableFilterHskIngredientContr
 import { createNewFilterHskIngredientValidator, disableFilterHskIngredientValidator, getFilterHskIngredientByIdValidator, updateFilterHskIngredientValidator } from '~/middlewares/filterHskIngredient.middlewares'
 import { createNewFilterHskProductTypeController, disableFilterHskProductTypeController, getAllFilterHskProductTypesController, getFilterHskProductTypeByIdController, searchFilterHskProductTypesController, updateFilterHskProductTypeController } from '~/controllers/filterHskProductType.controllers'
 import { createNewFilterHskProductTypeValidator, disableFilterHskProductTypeValidator, getFilterHskProductTypeByIdValidator, updateFilterHskProductTypeValidator } from '~/middlewares/filterHskProductType.middlewares'
+import { createNewFilterHskSizeController, disableFilterHskSizeController, getAllFilterHskSizesController, getFilterHskSizeByIdController, searchFilterHskSizesController, updateFilterHskSizeController } from '~/controllers/filterHskSize.controllers'
+import { createNewFilterHskSizeValidator, disableFilterHskSizeValidator, getFilterHskSizeByIdValidator, updateFilterHskSizeValidator } from '~/middlewares/filterHskSize.middlewares'
 
 const adminRouter = Router()
 //user management
@@ -399,5 +401,55 @@ adminRouter.put(
   filterMiddleware<disableFilterHskProductTypeReqBody>(['state']),
   disableFilterHskProductTypeValidator,
   wrapAsync(disableFilterHskProductTypeController)
+)
+
+//HSK SIZE FILTER
+adminRouter.get(
+  '/manage-filters/get-all-filter-hsk-sizes',
+  accessTokenValidator,
+  isAdminValidator,
+  wrapAsync(getAllFilterHskSizesController)
+)
+
+adminRouter.post(
+  '/manage-filters/create-new-filter-hsk-size',
+  accessTokenValidator,
+  isAdminValidator,
+  createNewFilterHskSizeValidator,
+  wrapAsync(createNewFilterHskSizeController)
+)
+
+adminRouter.get(
+  '/manage-filters/search-filter-hsk-size',
+  accessTokenValidator,
+  isAdminValidator,
+  searchFilterOptionNameValidator,
+  wrapAsync(searchFilterHskSizesController)
+)
+
+adminRouter.get(
+  '/manage-filters/get-filter-hsk-size-detail/:_id',
+  accessTokenValidator,
+  isAdminValidator,
+  getFilterHskSizeByIdValidator,
+  wrapAsync(getFilterHskSizeByIdController)
+)
+
+adminRouter.put(
+  '/manage-filters/update-filter-hsk-size/:_id',
+  accessTokenValidator,
+  isAdminValidator,
+  filterMiddleware<updateFilterHskSizeReqBody>(['option_name', 'category_name', 'category_param']),
+  updateFilterHskSizeValidator,
+  wrapAsync(updateFilterHskSizeController)
+)
+
+adminRouter.put(
+  '/manage-filters/update-filter-hsk-size-state/:_id',
+  accessTokenValidator,
+  isAdminValidator,
+  filterMiddleware<disableFilterHskSizeReqBody>(['state']),
+  disableFilterHskSizeValidator,
+  wrapAsync(disableFilterHskSizeController)
 )
 export default adminRouter

--- a/backend/src/routes/admin.routes.ts
+++ b/backend/src/routes/admin.routes.ts
@@ -43,7 +43,7 @@ import {
   searchFilterBrandsController,
   updateFilterBrandController
 } from '~/controllers/filterBrand.controllers'
-import { disableFilterBrandReqBody, disableFilterDacTinhReqBody, disableFilterHskIngredientReqBody, disableFilterHskProductTypeReqBody, disableFilterHskSizeReqBody, updateFilterBrandReqBody, updateFilterDacTinhReqBody, updateFilterHskIngredientReqBody, updateFilterHskProductTypeReqBody, updateFilterHskSizeReqBody } from '~/models/requests/Admin.requests'
+import { disableFilterBrandReqBody, disableFilterDacTinhReqBody, disableFilterHskIngredientReqBody, disableFilterHskProductTypeReqBody, disableFilterHskSizeReqBody, disableFilterHskSkinTypeReqBody, updateFilterBrandReqBody, updateFilterDacTinhReqBody, updateFilterHskIngredientReqBody, updateFilterHskProductTypeReqBody, updateFilterHskSizeReqBody, updateFilterHskSkinTypeReqBody } from '~/models/requests/Admin.requests'
 import {
   disableFilterBrandValidator,
   getFilterBrandByIdValidator,
@@ -57,6 +57,8 @@ import { createNewFilterHskProductTypeController, disableFilterHskProductTypeCon
 import { createNewFilterHskProductTypeValidator, disableFilterHskProductTypeValidator, getFilterHskProductTypeByIdValidator, updateFilterHskProductTypeValidator } from '~/middlewares/filterHskProductType.middlewares'
 import { createNewFilterHskSizeController, disableFilterHskSizeController, getAllFilterHskSizesController, getFilterHskSizeByIdController, searchFilterHskSizesController, updateFilterHskSizeController } from '~/controllers/filterHskSize.controllers'
 import { createNewFilterHskSizeValidator, disableFilterHskSizeValidator, getFilterHskSizeByIdValidator, updateFilterHskSizeValidator } from '~/middlewares/filterHskSize.middlewares'
+import { createNewFilterHskSkinTypeController, disableFilterHskSkinTypeController, getAllFilterHskSkinTypesController, getFilterHskSkinTypeByIdController, searchFilterHskSkinTypesController, updateFilterHskSkinTypeController } from '~/controllers/filterHskSkinType.controllers'
+import { createNewFilterHskSkinTypeValidator, disableFilterHskSkinTypeValidator, getFilterHskSkinTypeByIdValidator, updateFilterHskSkinTypeValidator } from '~/middlewares/filterHskSkinType.middlewares'
 
 const adminRouter = Router()
 //user management
@@ -451,5 +453,55 @@ adminRouter.put(
   filterMiddleware<disableFilterHskSizeReqBody>(['state']),
   disableFilterHskSizeValidator,
   wrapAsync(disableFilterHskSizeController)
+)
+
+//HSK SKIN TYPE FILTER
+adminRouter.get(
+  '/manage-filters/get-all-filter-hsk-skin-types',
+  accessTokenValidator,
+  isAdminValidator,
+  wrapAsync(getAllFilterHskSkinTypesController)
+)
+
+adminRouter.post(
+  '/manage-filters/create-new-filter-hsk-skin-type',
+  accessTokenValidator,
+  isAdminValidator,
+  createNewFilterHskSkinTypeValidator,
+  wrapAsync(createNewFilterHskSkinTypeController)
+)
+
+adminRouter.get(
+  '/manage-filters/search-filter-hsk-skin-type',
+  accessTokenValidator,
+  isAdminValidator,
+  searchFilterOptionNameValidator,
+  wrapAsync(searchFilterHskSkinTypesController)
+)
+
+adminRouter.get(
+  '/manage-filters/get-filter-hsk-skin-type-detail/:_id',
+  accessTokenValidator,
+  isAdminValidator,
+  getFilterHskSkinTypeByIdValidator,
+  wrapAsync(getFilterHskSkinTypeByIdController)
+)
+
+adminRouter.put(
+  '/manage-filters/update-filter-hsk-skin-type/:_id',
+  accessTokenValidator,
+  isAdminValidator,
+  filterMiddleware<updateFilterHskSkinTypeReqBody>(['option_name', 'category_name', 'category_param']),
+  updateFilterHskSkinTypeValidator,
+  wrapAsync(updateFilterHskSkinTypeController)
+)
+
+adminRouter.put(
+  '/manage-filters/update-filter-hsk-skin-type-state/:_id',
+  accessTokenValidator,
+  isAdminValidator,
+  filterMiddleware<disableFilterHskSkinTypeReqBody>(['state']),
+  disableFilterHskSkinTypeValidator,
+  wrapAsync(disableFilterHskSkinTypeController)
 )
 export default adminRouter

--- a/backend/src/routes/admin.routes.ts
+++ b/backend/src/routes/admin.routes.ts
@@ -43,7 +43,7 @@ import {
   searchFilterBrandsController,
   updateFilterBrandController
 } from '~/controllers/filterBrand.controllers'
-import { disableFilterBrandReqBody, disableFilterDacTinhReqBody, disableFilterHskIngredientReqBody, updateFilterBrandReqBody, updateFilterDacTinhReqBody, updateFilterHskIngredientReqBody } from '~/models/requests/Admin.requests'
+import { disableFilterBrandReqBody, disableFilterDacTinhReqBody, disableFilterHskIngredientReqBody, disableFilterHskProductTypeReqBody, updateFilterBrandReqBody, updateFilterDacTinhReqBody, updateFilterHskIngredientReqBody, updateFilterHskProductTypeReqBody } from '~/models/requests/Admin.requests'
 import {
   disableFilterBrandValidator,
   getFilterBrandByIdValidator,
@@ -53,6 +53,8 @@ import { createNewFilterDacTinhValidator, disableFilterDacTinhValidator, getFilt
 import { createNewFilterDacTinhController, disableFilterDacTinhController, getAllFilterDacTinhsController, getFilterDacTinhByIdController, searchFilterDacTinhsController, updateFilterDacTinhController } from '~/controllers/filterDacTinh.controllers'
 import { createNewFilterHskIngredientController, disableFilterHskIngredientController, getAllFilterHskIngredientsController, getFilterHskIngredientByIdController, searchFilterHskIngredientsController, updateFilterHskIngredientController } from '~/controllers/filterHskIngredient.controllers'
 import { createNewFilterHskIngredientValidator, disableFilterHskIngredientValidator, getFilterHskIngredientByIdValidator, updateFilterHskIngredientValidator } from '~/middlewares/filterHskIngredient.middlewares'
+import { createNewFilterHskProductTypeController, disableFilterHskProductTypeController, getAllFilterHskProductTypesController, getFilterHskProductTypeByIdController, searchFilterHskProductTypesController, updateFilterHskProductTypeController } from '~/controllers/filterHskProductType.controllers'
+import { createNewFilterHskProductTypeValidator, disableFilterHskProductTypeValidator, getFilterHskProductTypeByIdValidator, updateFilterHskProductTypeValidator } from '~/middlewares/filterHskProductType.middlewares'
 
 const adminRouter = Router()
 //user management
@@ -347,5 +349,55 @@ adminRouter.put(
   filterMiddleware<disableFilterHskIngredientReqBody>(['state']),
   disableFilterHskIngredientValidator,
   wrapAsync(disableFilterHskIngredientController)
+)
+
+//HSK Product Type filter
+adminRouter.get(
+  '/manage-filters/get-all-filter-hsk-product-types',
+  accessTokenValidator,
+  isAdminValidator,
+  wrapAsync(getAllFilterHskProductTypesController)
+)
+
+adminRouter.post(
+  '/manage-filters/create-new-filter-hsk-product-type',
+  accessTokenValidator,
+  isAdminValidator,
+  createNewFilterHskProductTypeValidator,
+  wrapAsync(createNewFilterHskProductTypeController)
+)
+
+adminRouter.get(
+  '/manage-filters/search-filter-hsk-product-type',
+  accessTokenValidator,
+  isAdminValidator,
+  searchFilterOptionNameValidator,
+  wrapAsync(searchFilterHskProductTypesController)
+)
+
+adminRouter.get(
+  '/manage-filters/get-filter-hsk-product-type-detail/:_id',
+  accessTokenValidator,
+  isAdminValidator,
+  getFilterHskProductTypeByIdValidator,
+  wrapAsync(getFilterHskProductTypeByIdController)
+)
+
+adminRouter.put(
+  '/manage-filters/update-filter-hsk-product-type/:_id',
+  accessTokenValidator,
+  isAdminValidator,
+  filterMiddleware<updateFilterHskProductTypeReqBody>(['option_name', 'description', 'category_name', 'category_param']),
+  updateFilterHskProductTypeValidator,
+  wrapAsync(updateFilterHskProductTypeController)
+)
+
+adminRouter.put(
+  '/manage-filters/update-filter-hsk-product-type-state/:_id',
+  accessTokenValidator,
+  isAdminValidator,
+  filterMiddleware<disableFilterHskProductTypeReqBody>(['state']),
+  disableFilterHskProductTypeValidator,
+  wrapAsync(disableFilterHskProductTypeController)
 )
 export default adminRouter

--- a/backend/src/services/filterHskProductType.services.ts
+++ b/backend/src/services/filterHskProductType.services.ts
@@ -1,4 +1,10 @@
 import { ObjectId } from 'mongodb'
+import { GenericFilterState } from '~/constants/enums'
+import HTTP_STATUS from '~/constants/httpStatus'
+import { ADMIN_MESSAGES } from '~/constants/messages'
+import { ErrorWithStatus } from '~/models/Errors'
+import { createNewFilterHskProductTypeReqBody, updateFilterHskProductTypeReqBody } from '~/models/requests/Admin.requests'
+import FilterHskProductType from '~/models/schemas/FilterHskProductType.schema'
 import databaseService from '~/services/database.services'
 
 class FilterHskProductTypeService {
@@ -7,6 +13,49 @@ class FilterHskProductTypeService {
       _id: new ObjectId(filter_hsk_product_type)
     })
     return Boolean(productType)
+  }
+
+  async createNewFilterProductType(payload: createNewFilterHskProductTypeReqBody) {
+    const filterID = new ObjectId()
+    const currentDate = new Date()
+    const vietnamTimezoneOffset = 7 * 60
+    const localTime = new Date(currentDate.getTime() + vietnamTimezoneOffset * 60 * 1000)
+
+    const result = await databaseService.filterHskProductType.insertOne(
+      new FilterHskProductType({
+        ...payload,
+        _id: filterID,
+        state: payload.state || GenericFilterState.ACTIVE,
+        created_at: localTime,
+        updated_at: localTime
+      })
+    )
+    return result
+  }
+
+  async updateFilterProductType(_id: string, payload: updateFilterHskProductTypeReqBody) {
+    try {
+      const currentDate = new Date()
+      const vietnamTimezoneOffset = 7 * 60
+      const localTime = new Date(currentDate.getTime() + vietnamTimezoneOffset * 60 * 1000)
+
+      const result = await databaseService.filterHskProductType.findOneAndUpdate(
+        { _id: new ObjectId(_id) },
+        {
+          $set: {
+            ...payload,
+            updated_at: localTime
+          }
+        },
+        { returnDocument: 'after' }
+      )
+      return result
+    } catch (error) {
+      throw new ErrorWithStatus({
+        message: ADMIN_MESSAGES.UPDATE_FILTER_PRODUCT_TYPE_FAILED,
+        status: HTTP_STATUS.INTERNAL_SERVER_ERROR
+      })
+    }
   }
 }
 const filterHskProductTypeService = new FilterHskProductTypeService()

--- a/backend/src/services/filterHskSize.services.ts
+++ b/backend/src/services/filterHskSize.services.ts
@@ -1,4 +1,10 @@
 import { ObjectId } from 'mongodb'
+import { GenericFilterState } from '~/constants/enums'
+import HTTP_STATUS from '~/constants/httpStatus'
+import { ADMIN_MESSAGES } from '~/constants/messages'
+import { ErrorWithStatus } from '~/models/Errors'
+import { createNewFilterHskSizeReqBody, updateFilterHskSizeReqBody } from '~/models/requests/Admin.requests'
+import FilterHskSize from '~/models/schemas/FilterHskSize.schema'
 import databaseService from '~/services/database.services'
 
 class FilterHskSizeService {
@@ -7,6 +13,49 @@ class FilterHskSizeService {
       _id: new ObjectId(filter_hsk_size)
     })
     return Boolean(size)
+  }
+
+  async createNewFilterSize(payload: createNewFilterHskSizeReqBody) {
+    const filterID = new ObjectId()
+    const currentDate = new Date()
+    const vietnamTimezoneOffset = 7 * 60
+    const localTime = new Date(currentDate.getTime() + vietnamTimezoneOffset * 60 * 1000)
+
+    const result = await databaseService.filterHskSize.insertOne(
+      new FilterHskSize({
+        ...payload,
+        _id: filterID,
+        state: payload.state || GenericFilterState.ACTIVE,
+        created_at: localTime,
+        updated_at: localTime
+      })
+    )
+    return result
+  }
+
+  async updateFilterSize(_id: string, payload: updateFilterHskSizeReqBody) {
+    try {
+      const currentDate = new Date()
+      const vietnamTimezoneOffset = 7 * 60
+      const localTime = new Date(currentDate.getTime() + vietnamTimezoneOffset * 60 * 1000)
+
+      const result = await databaseService.filterHskSize.findOneAndUpdate(
+        { _id: new ObjectId(_id) },
+        {
+          $set: {
+            ...payload,
+            updated_at: localTime
+          }
+        },
+        { returnDocument: 'after' }
+      )
+      return result
+    } catch (error) {
+      throw new ErrorWithStatus({
+        message: ADMIN_MESSAGES.UPDATE_FILTER_SIZE_FAILED,
+        status: HTTP_STATUS.INTERNAL_SERVER_ERROR
+      })
+    }
   }
 }
 const filterHskSizeService = new FilterHskSizeService()

--- a/backend/src/services/filterHskSkinType.services.ts
+++ b/backend/src/services/filterHskSkinType.services.ts
@@ -1,4 +1,10 @@
 import { ObjectId } from 'mongodb'
+import { GenericFilterState } from '~/constants/enums'
+import HTTP_STATUS from '~/constants/httpStatus'
+import { ADMIN_MESSAGES } from '~/constants/messages'
+import { ErrorWithStatus } from '~/models/Errors'
+import { createNewFilterHskSkinTypeReqBody, updateFilterHskSkinTypeReqBody } from '~/models/requests/Admin.requests'
+import FilterHskSkinType from '~/models/schemas/FilterHskSkinType.schema'
 import databaseService from '~/services/database.services'
 
 class FilterHskSkinTypeService {
@@ -7,6 +13,49 @@ class FilterHskSkinTypeService {
       _id: new ObjectId(filter_hsk_skin_type)
     })
     return Boolean(skinType)
+  }
+
+  async createNewFilterSkinType(payload: createNewFilterHskSkinTypeReqBody) {
+    const filterID = new ObjectId()
+    const currentDate = new Date()
+    const vietnamTimezoneOffset = 7 * 60
+    const localTime = new Date(currentDate.getTime() + vietnamTimezoneOffset * 60 * 1000)
+
+    const result = await databaseService.filterHskSkinType.insertOne(
+      new FilterHskSkinType({
+        ...payload,
+        _id: filterID,
+        state: payload.state || GenericFilterState.ACTIVE,
+        created_at: localTime,
+        updated_at: localTime
+      })
+    )
+    return result
+  }
+
+  async updateFilterSkinType(_id: string, payload: updateFilterHskSkinTypeReqBody) {
+    try {
+      const currentDate = new Date()
+      const vietnamTimezoneOffset = 7 * 60
+      const localTime = new Date(currentDate.getTime() + vietnamTimezoneOffset * 60 * 1000)
+
+      const result = await databaseService.filterHskSkinType.findOneAndUpdate(
+        { _id: new ObjectId(_id) },
+        {
+          $set: {
+            ...payload,
+            updated_at: localTime
+          }
+        },
+        { returnDocument: 'after' }
+      )
+      return result
+    } catch (error) {
+      throw new ErrorWithStatus({
+        message: ADMIN_MESSAGES.UPDATE_FILTER_SKIN_TYPE_FAILED,
+        status: HTTP_STATUS.INTERNAL_SERVER_ERROR
+      })
+    }
   }
 }
 const filterHskSkinTypeService = new FilterHskSkinTypeService()


### PR DESCRIPTION
Tiêu đề: feat: Thêm CRUD cho bộ lọc Loại sản phẩm, Kích thước và Loại da
Mô tả
Pull request này giới thiệu chức năng CRUD (Create, Read, Update, Delete) hoàn chỉnh cho ba loại bộ lọc sản phẩm mới, giúp quản trị viên có thể quản lý các tùy chọn lọc một cách hiệu quả.

Mục đích:
Mục tiêu chính là mở rộng khả năng lọc sản phẩm, cho phép người dùng tìm kiếm sản phẩm chính xác hơn dựa trên:

Loại sản phẩm (ví dụ: Kem Chống Nắng, Serum)

Kích thước (ví dụ: 250ml, 100ml)

Loại da (ví dụ: Da Dầu, Da Hỗn Hợp)

Các tính năng này được xây dựng để cung cấp cho quản trị viên các công cụ cần thiết để duy trì và cập nhật các tùy chọn bộ lọc này từ giao diện quản trị.

Các thay đổi chính
1. Backend API & Logic
Đã triển khai một bộ đầy đủ các endpoint API được bảo vệ cho từng loại bộ lọc (product_type, size, skin_type), bao gồm:

Controllers (/controllers): Tạo logic xử lý request cho việc tạo mới, lấy danh sách (có phân trang), lấy chi tiết, cập nhật, thay đổi trạng thái và tìm kiếm.

Services (/services): Xây dựng các service để xử lý logic nghiệp vụ và tương tác với cơ sở dữ liệu một cách an toàn.

Routes (/routes/admin.routes.ts): Thêm các route mới vào adminRouter để expose các API ra bên ngoài. Các route này đều yêu cầu quyền admin.

Middlewares (/middlewares): Thêm các validator để xác thực dữ liệu đầu vào (request body, params) cho các endpoint, đảm bảo tính toàn vẹn của dữ liệu.

Models (/models):

Schemas: Định nghĩa cấu trúc dữ liệu cho FilterHskProductType, FilterHskSize, và FilterHskSkinType trong MongoDB.

Requests: Tạo các interface TypeScript cho request body để tăng cường type-safety.

Constants (/constants/messages.ts): Bổ sung các thông báo lỗi và thành công mới để đảm bảo các phản hồi API nhất quán và dễ hiểu.

2. Tài liệu API (Swagger/OpenAPI)
OpenAPI Specs (/docs): Toàn bộ các endpoint mới đã được tài liệu hóa chi tiết bằng Swagger (OpenAPI).

Schemas & Payloads: Định nghĩa rõ ràng các schema cho request body, response object, và các đối tượng phân trang.

Cập nhật openapi.json: File JSON đã được tạo lại để phản ánh tất cả các thay đổi, giúp Swagger UI hiển thị tài liệu API mới một cách chính xác.

Tóm tắt các tệp đã thay đổi
admin.routes.ts: Thêm 18 route mới cho 3 bộ lọc (mỗi bộ lọc có 6 endpoints: get-all, create, get-detail, update, update-state, search).

*.controllers.ts, *.services.ts, *.middlewares.ts, *.schema.ts: Tạo các tệp mới để đóng gói logic cho từng loại bộ lọc.

/docs & openapi.json: Cập nhật và thêm nhiều file YAML để tài liệu hóa API, dẫn đến sự thay đổi lớn trong file openapi.json được tạo tự động.