### PR TITLE
Feature/crud filters and send mail

### DIFF
--- a/backend/public/openapi.json
+++ b/backend/public/openapi.json
@@ -3399,6 +3399,19 @@
               }
             }
           },
+          "400": {
+            "description": "Bad Request (VD:Cố gắng cập nhật một filter đang ở trạng thái không hoạt động).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorStatusResponse",
+                  "example": {
+                    "message": "Cannot update an inactive filter. Please activate it first."
+                  }
+                }
+              }
+            }
+          },
           "401": {
             "$ref": "#/components/schemas/ErrorStatusResponse"
           },
@@ -3711,6 +3724,19 @@
           },
           "422": {
             "$ref": "#/components/schemas/ErrorValidationResponse"
+          },
+          "400'": {
+            "description": "Bad Request (VD:Cố gắng cập nhật một filter đang ở trạng thái không hoạt động).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorStatusResponse",
+                  "example": {
+                    "message": "Cannot update an inactive filter. Please activate it first."
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -4008,6 +4034,19 @@
           },
           "422": {
             "$ref": "#/components/schemas/ErrorValidationResponse"
+          },
+          "400'": {
+            "description": "Bad Request (VD:Cố gắng cập nhật một filter đang ở trạng thái không hoạt động).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorStatusResponse",
+                  "example": {
+                    "message": "Cannot update an inactive filter. Please activate it first."
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -4300,6 +4339,19 @@
           },
           "422": {
             "$ref": "#/components/schemas/ErrorValidationResponse"
+          },
+          "400'": {
+            "description": "Bad Request (VD:Cố gắng cập nhật một filter đang ở trạng thái không hoạt động).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorStatusResponse",
+                  "example": {
+                    "message": "Cannot update an inactive filter. Please activate it first."
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -4591,6 +4643,19 @@
           },
           "422": {
             "$ref": "#/components/schemas/ErrorValidationResponse"
+          },
+          "400'": {
+            "description": "Bad Request (VD:Cố gắng cập nhật một filter đang ở trạng thái không hoạt động).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorStatusResponse",
+                  "example": {
+                    "message": "Cannot update an inactive filter. Please activate it first."
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -4882,6 +4947,19 @@
           },
           "422": {
             "$ref": "#/components/schemas/ErrorValidationResponse"
+          },
+          "400'": {
+            "description": "Bad Request (VD:Cố gắng cập nhật một filter đang ở trạng thái không hoạt động).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorStatusResponse",
+                  "example": {
+                    "message": "Cannot update an inactive filter. Please activate it first."
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -5173,6 +5251,19 @@
           },
           "422": {
             "$ref": "#/components/schemas/ErrorValidationResponse"
+          },
+          "400'": {
+            "description": "Bad Request (VD:Cố gắng cập nhật một filter đang ở trạng thái không hoạt động).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorStatusResponse",
+                  "example": {
+                    "message": "Cannot update an inactive filter. Please activate it first."
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -5464,6 +5555,19 @@
           },
           "422": {
             "$ref": "#/components/schemas/ErrorValidationResponse"
+          },
+          "400'": {
+            "description": "Bad Request (VD:Cố gắng cập nhật một filter đang ở trạng thái không hoạt động).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorStatusResponse",
+                  "example": {
+                    "message": "Cannot update an inactive filter. Please activate it first."
+                  }
+                }
+              }
+            }
           }
         }
       }

--- a/backend/public/openapi.json
+++ b/backend/public/openapi.json
@@ -5281,6 +5281,297 @@
           }
         }
       }
+    },
+    "/admin/manage-filters/create-new-filter-hsk-origin": {
+      "post": {
+        "tags": [
+          "Admin - Filter Origin"
+        ],
+        "summary": "(Admin) Create a New HSK Origin Filter",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateFilterHskOriginReqBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Filter nguồn gốc được tạo thành công.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "422": {
+            "$ref": "#/components/schemas/ErrorValidationResponse"
+          }
+        }
+      }
+    },
+    "/admin/manage-filters/get-all-filter-hsk-origins": {
+      "get": {
+        "tags": [
+          "Admin - Filter Origin"
+        ],
+        "summary": "(Admin) Get All HSK Origin Filters",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PageQuery"
+          },
+          {
+            "$ref": "#/components/parameters/LimitQuery"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Trả về danh sách các filter nguồn gốc.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedFilterHskOriginResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          }
+        }
+      }
+    },
+    "/admin/manage-filters/get-filter-hsk-origin-detail/{_id}": {
+      "get": {
+        "tags": [
+          "Admin - Filter Origin"
+        ],
+        "summary": "(Admin) Get HSK Origin Filter by ID",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "mongoId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Chi tiết filter nguồn gốc.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FilterHskOrigin"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "404": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          }
+        }
+      }
+    },
+    "/admin/manage-filters/update-filter-hsk-origin/{_id}": {
+      "put": {
+        "tags": [
+          "Admin - Filter Origin"
+        ],
+        "summary": "(Admin) Update an HSK Origin Filter",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "mongoId"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateFilterHskOriginReqBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Filter nguồn gốc được cập nhật thành công.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FilterHskOrigin"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "404": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "422": {
+            "$ref": "#/components/schemas/ErrorValidationResponse"
+          }
+        }
+      }
+    },
+    "/admin/manage-filters/update-filter-hsk-origin-state/{_id}": {
+      "put": {
+        "tags": [
+          "Admin - Filter Origin"
+        ],
+        "summary": "(Admin) Update HSK Origin Filter State",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "mongoId"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DisableFilterHskOriginReqBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Trạng thái filter nguồn gốc được cập nhật thành công.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FilterHskOrigin"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "404": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "422": {
+            "$ref": "#/components/schemas/ErrorValidationResponse"
+          }
+        }
+      }
+    },
+    "/admin/manage-filters/search-filter-hsk-origin": {
+      "get": {
+        "tags": [
+          "Admin - Filter Origin"
+        ],
+        "summary": "(Admin) Search HSK Origin Filters by Name",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PageQuery"
+          },
+          {
+            "$ref": "#/components/parameters/LimitQuery"
+          },
+          {
+            "name": "keyword",
+            "in": "query",
+            "description": "Từ khóa tìm kiếm trong tên nguồn gốc.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Trả về danh sách các filter nguồn gốc phù hợp.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedFilterHskOriginResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -7707,6 +7998,119 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/FilterHskUses"
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/PaginatedUserResponse/properties/pagination"
+          }
+        }
+      },
+      "FilterHskOrigin": {
+        "type": "object",
+        "description": "Đại diện cho một đối tượng filter Nguồn Gốc (Origin).",
+        "properties": {
+          "_id": {
+            "type": "string",
+            "format": "mongoId"
+          },
+          "option_name": {
+            "type": "string",
+            "example": "Hàn Quốc"
+          },
+          "category_name": {
+            "type": "string",
+            "example": "Nguồn Gốc HSK"
+          },
+          "category_param": {
+            "type": "string",
+            "example": "han-quoc"
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "INACTIVE",
+              "ACTIVE"
+            ]
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "CreateFilterHskOriginReqBody": {
+        "type": "object",
+        "required": [
+          "option_name",
+          "category_name",
+          "category_param"
+        ],
+        "properties": {
+          "option_name": {
+            "type": "string",
+            "example": "Nhật Bản"
+          },
+          "category_name": {
+            "type": "string",
+            "example": "Nguồn Gốc HSK"
+          },
+          "category_param": {
+            "type": "string",
+            "example": "nhat-ban"
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "INACTIVE",
+              "ACTIVE"
+            ],
+            "default": "ACTIVE"
+          }
+        }
+      },
+      "UpdateFilterHskOriginReqBody": {
+        "type": "object",
+        "description": "Chỉ bao gồm các trường cần cập nhật cho nguồn gốc.",
+        "properties": {
+          "option_name": {
+            "type": "string"
+          },
+          "category_name": {
+            "type": "string"
+          },
+          "category_param": {
+            "type": "string"
+          }
+        }
+      },
+      "DisableFilterHskOriginReqBody": {
+        "type": "object",
+        "required": [
+          "state"
+        ],
+        "properties": {
+          "state": {
+            "type": "string",
+            "description": "Trạng thái mới cho filter nguồn gốc.",
+            "enum": [
+              "INACTIVE",
+              "ACTIVE"
+            ],
+            "example": "INACTIVE"
+          }
+        }
+      },
+      "PaginatedFilterHskOriginResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterHskOrigin"
             }
           },
           "pagination": {

--- a/backend/public/openapi.json
+++ b/backend/public/openapi.json
@@ -5572,6 +5572,358 @@
           }
         }
       }
+    },
+    "/admin/manage-filters/get-active-filter-brands": {
+      "get": {
+        "tags": [
+          "Admin - Filter Brand"
+        ],
+        "summary": "(Admin) Get All Active Filter Brands",
+        "description": "Lấy danh sách tất cả các filter thương hiệu đang hoạt động để sử dụng trong việc tạo/cập nhật sản phẩm.",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Trả về một mảng các đối tượng filter thương hiệu.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Get active filter brands successfully"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/FilterBrand"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          }
+        }
+      }
+    },
+    "/admin/manage-filters/get-active-filter-dac-tinhs": {
+      "get": {
+        "tags": [
+          "Admin - Filter Dac Tinh"
+        ],
+        "summary": "(Admin) Get All Active Filter Dac Tinhs",
+        "description": "Lấy danh sách tất cả các filter đặc tính đang hoạt động.",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Trả về một mảng các đối tượng filter đặc tính.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Get active filter dac tinhs successfully"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/FilterDacTinh"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          }
+        }
+      }
+    },
+    "/admin/manage-filters/get-active-filter-hsk-ingredients": {
+      "get": {
+        "tags": [
+          "Admin - Filter Ingredient"
+        ],
+        "summary": "(Admin) Get All Active HSK Ingredient Filters",
+        "description": "Lấy danh sách tất cả các filter thành phần đang hoạt động.",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Trả về một mảng các đối tượng filter thành phần.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Get active filter ingredients successfully"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/FilterHskIngredient"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          }
+        }
+      }
+    },
+    "/admin/manage-filters/get-active-filter-hsk-product-types": {
+      "get": {
+        "tags": [
+          "Admin - Filter Product Type"
+        ],
+        "summary": "(Admin) Get All Active HSK Product Type Filters",
+        "description": "Lấy danh sách tất cả các filter loại sản phẩm đang hoạt động.",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Trả về một mảng các đối tượng filter loại sản phẩm.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Get active filter product types successfully"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/FilterHskProductType"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          }
+        }
+      }
+    },
+    "/admin/manage-filters/get-active-filter-hsk-sizes": {
+      "get": {
+        "tags": [
+          "Admin - Filter Size"
+        ],
+        "summary": "(Admin) Get All Active HSK Size Filters",
+        "description": "Lấy danh sách tất cả các filter kích thước đang hoạt động.",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Trả về một mảng các đối tượng filter kích thước.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Get active filter sizes successfully"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/FilterHskSize"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          }
+        }
+      }
+    },
+    "/admin/manage-filters/get-active-filter-hsk-skin-types": {
+      "get": {
+        "tags": [
+          "Admin - Filter Skin Type"
+        ],
+        "summary": "(Admin) Get All Active HSK Skin Type Filters",
+        "description": "Lấy danh sách tất cả các filter loại da đang hoạt động.",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Trả về một mảng các đối tượng filter loại da.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Get active filter skin types successfully"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/FilterHskSkinType"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          }
+        }
+      }
+    },
+    "/admin/manage-filters/get-active-filter-hsk-uses": {
+      "get": {
+        "tags": [
+          "Admin - Filter Uses"
+        ],
+        "summary": "(Admin) Get All Active HSK Uses Filters",
+        "description": "Lấy danh sách tất cả các filter công dụng đang hoạt động.",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Trả về một mảng các đối tượng filter công dụng.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Get active filter uses successfully"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/FilterHskUses"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          }
+        }
+      }
+    },
+    "/admin/manage-filters/get-active-filter-hsk-origins": {
+      "get": {
+        "tags": [
+          "Admin - Filter Origin"
+        ],
+        "summary": "(Admin) Get All Active HSK Origin Filters",
+        "description": "Lấy danh sách tất cả các filter nguồn gốc đang hoạt động.",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Trả về một mảng các đối tượng filter nguồn gốc.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Get active filter origins successfully"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/FilterHskOrigin"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          }
+        }
+      }
     }
   },
   "components": {

--- a/backend/public/openapi.json
+++ b/backend/public/openapi.json
@@ -4990,6 +4990,297 @@
           }
         }
       }
+    },
+    "/admin/manage-filters/create-new-filter-hsk-uses": {
+      "post": {
+        "tags": [
+          "Admin - Filter Uses"
+        ],
+        "summary": "(Admin) Create a New HSK Uses Filter",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateFilterHskUsesReqBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Filter công dụng được tạo thành công.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessageResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "422": {
+            "$ref": "#/components/schemas/ErrorValidationResponse"
+          }
+        }
+      }
+    },
+    "/admin/manage-filters/get-all-filter-hsk-uses": {
+      "get": {
+        "tags": [
+          "Admin - Filter Uses"
+        ],
+        "summary": "(Admin) Get All HSK Uses Filters",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PageQuery"
+          },
+          {
+            "$ref": "#/components/parameters/LimitQuery"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Trả về danh sách các filter công dụng.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedFilterHskUsesResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          }
+        }
+      }
+    },
+    "/admin/manage-filters/get-filter-hsk-uses-detail/{_id}": {
+      "get": {
+        "tags": [
+          "Admin - Filter Uses"
+        ],
+        "summary": "(Admin) Get HSK Uses Filter by ID",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "mongoId"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Chi tiết filter công dụng.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FilterHskUses"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "404": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          }
+        }
+      }
+    },
+    "/admin/manage-filters/update-filter-hsk-uses/{_id}": {
+      "put": {
+        "tags": [
+          "Admin - Filter Uses"
+        ],
+        "summary": "(Admin) Update an HSK Uses Filter",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "mongoId"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateFilterHskUsesReqBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Filter công dụng được cập nhật thành công.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FilterHskUses"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "404": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "422": {
+            "$ref": "#/components/schemas/ErrorValidationResponse"
+          }
+        }
+      }
+    },
+    "/admin/manage-filters/update-filter-hsk-uses-state/{_id}": {
+      "put": {
+        "tags": [
+          "Admin - Filter Uses"
+        ],
+        "summary": "(Admin) Update HSK Uses Filter State",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "mongoId"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DisableFilterHskUsesReqBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Trạng thái filter công dụng được cập nhật thành công.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FilterHskUses"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "404": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "422": {
+            "$ref": "#/components/schemas/ErrorValidationResponse"
+          }
+        }
+      }
+    },
+    "/admin/manage-filters/search-filter-hsk-uses": {
+      "get": {
+        "tags": [
+          "Admin - Filter Uses"
+        ],
+        "summary": "(Admin) Search HSK Uses Filters by Name",
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/PageQuery"
+          },
+          {
+            "$ref": "#/components/parameters/LimitQuery"
+          },
+          {
+            "name": "keyword",
+            "in": "query",
+            "description": "Từ khóa tìm kiếm trong tên công dụng.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Trả về danh sách các filter công dụng phù hợp.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedFilterHskUsesResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          },
+          "403": {
+            "$ref": "#/components/schemas/ErrorStatusResponse"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -7303,6 +7594,119 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/FilterHskSkinType"
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/PaginatedUserResponse/properties/pagination"
+          }
+        }
+      },
+      "FilterHskUses": {
+        "type": "object",
+        "description": "Đại diện cho một đối tượng filter Công Dụng (Uses).",
+        "properties": {
+          "_id": {
+            "type": "string",
+            "format": "mongoId"
+          },
+          "option_name": {
+            "type": "string",
+            "example": "Phục Hồi Da"
+          },
+          "category_name": {
+            "type": "string",
+            "example": "Công Dụng HSK"
+          },
+          "category_param": {
+            "type": "string",
+            "example": "phuc-hoi-da"
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "INACTIVE",
+              "ACTIVE"
+            ]
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "CreateFilterHskUsesReqBody": {
+        "type": "object",
+        "required": [
+          "option_name",
+          "category_name",
+          "category_param"
+        ],
+        "properties": {
+          "option_name": {
+            "type": "string",
+            "example": "Trị Mụn"
+          },
+          "category_name": {
+            "type": "string",
+            "example": "Công Dụng HSK"
+          },
+          "category_param": {
+            "type": "string",
+            "example": "tri-mun"
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "INACTIVE",
+              "ACTIVE"
+            ],
+            "default": "ACTIVE"
+          }
+        }
+      },
+      "UpdateFilterHskUsesReqBody": {
+        "type": "object",
+        "description": "Chỉ bao gồm các trường cần cập nhật cho công dụng.",
+        "properties": {
+          "option_name": {
+            "type": "string"
+          },
+          "category_name": {
+            "type": "string"
+          },
+          "category_param": {
+            "type": "string"
+          }
+        }
+      },
+      "DisableFilterHskUsesReqBody": {
+        "type": "object",
+        "required": [
+          "state"
+        ],
+        "properties": {
+          "state": {
+            "type": "string",
+            "description": "Trạng thái mới cho filter công dụng.",
+            "enum": [
+              "INACTIVE",
+              "ACTIVE"
+            ],
+            "example": "INACTIVE"
+          }
+        }
+      },
+      "PaginatedFilterHskUsesResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterHskUses"
             }
           },
           "pagination": {

--- a/backend/src/constants/messages.ts
+++ b/backend/src/constants/messages.ts
@@ -317,6 +317,20 @@ export const ADMIN_MESSAGES = {
   CREATE_NEW_FILTER_USES_SUCCESS: 'Create new filter uses successfully',
   UPDATE_FILTER_USES_SUCCESS: 'Update filter uses successfully',
   UPDATE_FILTER_USES_STATE_SUCCESS: 'Filter uses update state successfully',
+  //filter origin
+  UPDATE_FILTER_ORIGIN_FAILED: 'Update filter origin failed',
+  FILTER_ORIGIN_ID_IS_INVALID: 'Filter origin ID is invalid',
+  FILTER_ORIGIN_NOT_FOUND: 'Filter origin not found',
+  FILTER_ORIGIN_OPTION_NAME_IS_REQUIRED: 'Filter origin option name is required',
+  FILTER_ORIGIN_OPTION_NAME_MUST_BE_STRING: 'Filter origin option name must be a string',
+  FILTER_ORIGIN_CATEGORY_NAME_IS_REQUIRED: 'Filter origin category name is required',
+  FILTER_ORIGIN_CATEGORY_NAME_MUST_BE_STRING: 'Filter origin category name must be a string',
+  FILTER_ORIGIN_CATEGORY_PARAM_IS_REQUIRED: 'Filter origin category param is required',
+  FILTER_ORIGIN_CATEGORY_PARAM_MUST_BE_STRING: 'Filter origin category param must be a string',
+  FILTER_ORIGIN_STATE_MUST_BE_A_STRING: 'Filter origin state must be a string',
+  CREATE_NEW_FILTER_ORIGIN_SUCCESS: 'Create new filter origin successfully',
+  UPDATE_FILTER_ORIGIN_SUCCESS: 'Update filter origin successfully',
+  UPDATE_FILTER_ORIGIN_STATE_SUCCESS: 'Filter origin update state successfully',
   
 
 } as const

--- a/backend/src/constants/messages.ts
+++ b/backend/src/constants/messages.ts
@@ -331,8 +331,17 @@ export const ADMIN_MESSAGES = {
   CREATE_NEW_FILTER_ORIGIN_SUCCESS: 'Create new filter origin successfully',
   UPDATE_FILTER_ORIGIN_SUCCESS: 'Update filter origin successfully',
   UPDATE_FILTER_ORIGIN_STATE_SUCCESS: 'Filter origin update state successfully',
-  
 
+  //filter inactive cannot create new product
+  FILTER_BRAND_IS_INACTIVE: 'Selected brand is currently inactive. Please choose an active one.',
+  FILTER_DAC_TINH_IS_INACTIVE: 'Selected characteristic is currently inactive. Please choose an active one.',
+  FILTER_INGREDIENT_IS_INACTIVE: 'Selected ingredient is currently inactive. Please choose an active one.',
+  FILTER_PRODUCT_TYPE_IS_INACTIVE: 'Selected product type is currently inactive. Please choose an active one.',
+  FILTER_SIZE_IS_INACTIVE: 'Selected size is currently inactive. Please choose an active one.',
+  FILTER_SKIN_TYPE_IS_INACTIVE: 'Selected skin type is currently inactive. Please choose an active one.',
+  FILTER_USES_IS_INACTIVE: 'Selected uses is currently inactive. Please choose an active one.',
+  FILTER_ORIGIN_IS_INACTIVE: 'Selected origin is currently inactive. Please choose an active one.',
+  
 } as const
 
 export const CART_MESSAGES = {

--- a/backend/src/constants/messages.ts
+++ b/backend/src/constants/messages.ts
@@ -349,7 +349,8 @@ export const ADMIN_MESSAGES = {
   GET_ACTIVE_FILTER_SKIN_TYPES_SUCCESSFULLY: 'Get active filter skin types successfully',
   GET_ACTIVE_FILTER_USES_SUCCESSFULLY: 'Get active filter uses successfully',
   GET_ACTIVE_FILTER_ORIGINS_SUCCESSFULLY: 'Get active filter origins successfully',
-
+  //filter is inactive cannot update
+  FILTER_IS_INACTIVE_CANNOT_UPDATE: 'Cannot update an inactive filter. Please activate it first.'
 } as const
 
 export const CART_MESSAGES = {

--- a/backend/src/constants/messages.ts
+++ b/backend/src/constants/messages.ts
@@ -331,7 +331,6 @@ export const ADMIN_MESSAGES = {
   CREATE_NEW_FILTER_ORIGIN_SUCCESS: 'Create new filter origin successfully',
   UPDATE_FILTER_ORIGIN_SUCCESS: 'Update filter origin successfully',
   UPDATE_FILTER_ORIGIN_STATE_SUCCESS: 'Filter origin update state successfully',
-
   //filter inactive cannot create new product
   FILTER_BRAND_IS_INACTIVE: 'Selected brand is currently inactive. Please choose an active one.',
   FILTER_DAC_TINH_IS_INACTIVE: 'Selected characteristic is currently inactive. Please choose an active one.',
@@ -341,7 +340,16 @@ export const ADMIN_MESSAGES = {
   FILTER_SKIN_TYPE_IS_INACTIVE: 'Selected skin type is currently inactive. Please choose an active one.',
   FILTER_USES_IS_INACTIVE: 'Selected uses is currently inactive. Please choose an active one.',
   FILTER_ORIGIN_IS_INACTIVE: 'Selected origin is currently inactive. Please choose an active one.',
-  
+  //api get all filter có state được quyền create và update product
+  GET_ACTIVE_FILTER_BRANDS_SUCCESSFULLY: 'Get active filter brands successfully',
+  GET_ACTIVE_FILTER_DAC_TINH_SUCCESSFULLY: 'Get active filter dac tinhs successfully',
+  GET_ACTIVE_FILTER_INGREDIENTS_SUCCESSFULLY: 'Get active filter ingredients successfully',
+  GET_ACTIVE_FILTER_PRODUCT_TYPES_SUCCESSFULLY: 'Get active filter product types successfully',
+  GET_ACTIVE_FILTER_SIZES_SUCCESSFULLY: 'Get active filter sizes successfully',
+  GET_ACTIVE_FILTER_SKIN_TYPES_SUCCESSFULLY: 'Get active filter skin types successfully',
+  GET_ACTIVE_FILTER_USES_SUCCESSFULLY: 'Get active filter uses successfully',
+  GET_ACTIVE_FILTER_ORIGINS_SUCCESSFULLY: 'Get active filter origins successfully',
+
 } as const
 
 export const CART_MESSAGES = {

--- a/backend/src/constants/messages.ts
+++ b/backend/src/constants/messages.ts
@@ -302,7 +302,23 @@ export const ADMIN_MESSAGES = {
   FILTER_SKIN_TYPE_STATE_MUST_BE_A_STRING: 'Filter skin type state must be a string',
   CREATE_NEW_FILTER_SKIN_TYPE_SUCCESS: 'Create new filter skin type successfully',
   UPDATE_FILTER_SKIN_TYPE_SUCCESS: 'Update filter skin type successfully',
-  UPDATE_FILTER_SKIN_TYPE_STATE_SUCCESS: 'Filter skin type update state successfully'
+  UPDATE_FILTER_SKIN_TYPE_STATE_SUCCESS: 'Filter skin type update state successfully',
+  //filter uses
+  UPDATE_FILTER_USES_FAILED: 'Update filter uses failed',
+  FILTER_USES_ID_IS_INVALID: 'Filter uses ID is invalid',
+  FILTER_USES_NOT_FOUND: 'Filter uses not found',
+  FILTER_USES_OPTION_NAME_IS_REQUIRED: 'Filter uses option name is required',
+  FILTER_USES_OPTION_NAME_MUST_BE_STRING: 'Filter uses option name must be a string',
+  FILTER_USES_CATEGORY_NAME_IS_REQUIRED: 'Filter uses category name is required',
+  FILTER_USES_CATEGORY_NAME_MUST_BE_STRING: 'Filter uses category name must be a string',
+  FILTER_USES_CATEGORY_PARAM_IS_REQUIRED: 'Filter uses category param is required',
+  FILTER_USES_CATEGORY_PARAM_MUST_BE_STRING: 'Filter uses category param must be a string',
+  FILTER_USES_STATE_MUST_BE_A_STRING: 'Filter uses state must be a string',
+  CREATE_NEW_FILTER_USES_SUCCESS: 'Create new filter uses successfully',
+  UPDATE_FILTER_USES_SUCCESS: 'Update filter uses successfully',
+  UPDATE_FILTER_USES_STATE_SUCCESS: 'Filter uses update state successfully',
+  
+
 } as const
 
 export const CART_MESSAGES = {

--- a/backend/src/controllers/filterBrand.controllers.ts
+++ b/backend/src/controllers/filterBrand.controllers.ts
@@ -7,6 +7,7 @@ import filterBrandService from '~/services/filterBrand.services'
 import { ADMIN_MESSAGES } from '~/constants/messages'
 import { Filter, ObjectId } from 'mongodb'
 import FilterBrand from '~/models/schemas/FilterBrand.schema'
+import { FilterBrandState } from '~/constants/enums'
 
 export const getAllFilterBrandsController = async (req: Request, res: Response, next: NextFunction) => {
   await sendPaginatedResponse(res, next, databaseService.filterBrand, req.query)
@@ -93,3 +94,22 @@ export const searchFilterBrandsController = async (req: Request, res: Response, 
 
   await sendPaginatedResponse(res, next, databaseService.filterBrand, req.query, filter)
 }
+
+export const getActiveFilterBrandsController = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const activeStates = [
+      FilterBrandState.ACTIVE,
+      FilterBrandState.COLLABORATION,
+      FilterBrandState.PARTNERSHIP,
+      FilterBrandState.EXCLUSIVE,
+      FilterBrandState.LIMITED_EDITION
+    ];
+    const result = await databaseService.filterBrand.find({ state: { $in: activeStates } }).toArray();
+    res.json({
+      message: ADMIN_MESSAGES.GET_ACTIVE_FILTER_BRANDS_SUCCESSFULLY,
+      data: result
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/src/controllers/filterDacTinh.controllers.ts
+++ b/backend/src/controllers/filterDacTinh.controllers.ts
@@ -11,6 +11,7 @@ import filterDacTinhService from '~/services/filterDacTinh.services'
 import { Filter, ObjectId } from 'mongodb'
 import { ADMIN_MESSAGES } from '~/constants/messages'
 import FilterDacTinh from '~/models/schemas/FilterDacTinh.schema'
+import { GenericFilterState } from '~/constants/enums'
 
 export const getAllFilterDacTinhsController = async (req: Request, res: Response, next: NextFunction) => {
   await sendPaginatedResponse(res, next, databaseService.filterDacTinh, req.query)
@@ -91,4 +92,16 @@ export const searchFilterDacTinhsController = async (req: Request, res: Response
   }
 
   await sendPaginatedResponse(res, next, databaseService.filterDacTinh, req.query, filter)
+}
+
+export const getActiveFilterDacTinhsController = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const result = await databaseService.filterDacTinh.find({ state: GenericFilterState.ACTIVE }).toArray()
+    res.json({
+      message: ADMIN_MESSAGES.GET_ACTIVE_FILTER_DAC_TINH_SUCCESSFULLY,
+      data: result
+    })
+  } catch (error) {
+    next(error)
+  }
 }

--- a/backend/src/controllers/filterHskIngredient.controllers.ts
+++ b/backend/src/controllers/filterHskIngredient.controllers.ts
@@ -13,6 +13,7 @@ import { getLocalTime } from '~/utils/date'
 import { Filter } from 'mongodb'
 import FilterHskIngredient from '~/models/schemas/FilterHskIngredient.schema'
 import { ADMIN_MESSAGES } from '~/constants/messages'
+import { GenericFilterState } from '~/constants/enums'
 
 export const getAllFilterHskIngredientsController = async (req: Request, res: Response, next: NextFunction) => {
   await sendPaginatedResponse(res, next, databaseService.filterHskIngredient, req.query)
@@ -80,4 +81,16 @@ export const searchFilterHskIngredientsController = async (req: Request, res: Re
     filter.option_name = { $regex: keyword as string, $options: 'i' }
   }
   await sendPaginatedResponse(res, next, databaseService.filterHskIngredient, req.query, filter)
+}
+
+export const getActiveFilterHskIngredientsController = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const result = await databaseService.filterHskIngredient.find({ state: GenericFilterState.ACTIVE }).toArray()
+    res.json({
+      message: ADMIN_MESSAGES.GET_ACTIVE_FILTER_INGREDIENTS_SUCCESSFULLY,
+      data: result
+    })
+  } catch (error) {
+    next(error)
+  }
 }

--- a/backend/src/controllers/filterHskOrigin.controllers.ts
+++ b/backend/src/controllers/filterHskOrigin.controllers.ts
@@ -15,6 +15,7 @@ import { Filter } from 'mongodb'
 import FilterHskOrigin from '~/models/schemas/FilterHskOrigin.schema'
 import { ADMIN_MESSAGES } from '~/constants/messages'
 import filterOriginService from '~/services/filterOrigin.services'
+import { GenericFilterState } from '~/constants/enums'
 
 export const getAllFilterHskOriginsController = async (req: Request, res: Response, next: NextFunction) => {
   await sendPaginatedResponse(res, next, databaseService.filterOrigin, req.query)
@@ -74,3 +75,15 @@ export const searchFilterHskOriginsController = async (req: Request, res: Respon
   }
   await sendPaginatedResponse(res, next, databaseService.filterOrigin, req.query, filter)
 }
+
+export const getActiveFilterHskOriginsController = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const result = await databaseService.filterOrigin.find({ state: GenericFilterState.ACTIVE }).toArray();
+    res.json({
+      message: ADMIN_MESSAGES.GET_ACTIVE_FILTER_ORIGINS_SUCCESSFULLY,
+      data: result
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/src/controllers/filterHskOrigin.controllers.ts
+++ b/backend/src/controllers/filterHskOrigin.controllers.ts
@@ -1,0 +1,76 @@
+// src/controllers/filterHskOrigin.controllers.ts
+
+import { Request, Response, NextFunction } from 'express'
+import { ParamsDictionary } from 'express-serve-static-core'
+import { sendPaginatedResponse } from '~/utils/pagination.helper'
+import databaseService from '~/services/database.services'
+import {
+  createNewFilterHskOriginReqBody,
+  disableFilterHskOriginReqBody,
+  updateFilterHskOriginReqBody
+} from '~/models/requests/Admin.requests'
+import { ObjectId } from 'mongodb'
+import { getLocalTime } from '~/utils/date'
+import { Filter } from 'mongodb'
+import FilterHskOrigin from '~/models/schemas/FilterHskOrigin.schema'
+import { ADMIN_MESSAGES } from '~/constants/messages'
+import filterOriginService from '~/services/filterOrigin.services'
+
+export const getAllFilterHskOriginsController = async (req: Request, res: Response, next: NextFunction) => {
+  await sendPaginatedResponse(res, next, databaseService.filterOrigin, req.query)
+}
+
+export const createNewFilterHskOriginController = async (
+  req: Request<ParamsDictionary, any, createNewFilterHskOriginReqBody>,
+  res: Response
+) => {
+  const result = await filterOriginService.createNewFilterOrigin(req.body)
+  res.json({ message: ADMIN_MESSAGES.CREATE_NEW_FILTER_ORIGIN_SUCCESS, result })
+}
+
+export const getFilterHskOriginByIdController = async (req: Request<{ _id: string }>, res: Response) => {
+  const { _id } = req.params
+  const result = await databaseService.filterOrigin.findOne({ _id: new ObjectId(_id) })
+  if (!result) {
+    res.status(404).json({
+      message: ADMIN_MESSAGES.FILTER_ORIGIN_NOT_FOUND
+    })
+  }
+  res.json({ data: result })
+}
+
+export const updateFilterHskOriginController = async (
+  req: Request<{ _id: string }, any, updateFilterHskOriginReqBody>,
+  res: Response
+) => {
+  const { _id } = req.params
+  const result = await filterOriginService.updateFilterOrigin(_id, req.body)
+  res.json({ message: ADMIN_MESSAGES.UPDATE_FILTER_ORIGIN_SUCCESS, result })
+}
+
+export const disableFilterHskOriginController = async (
+  req: Request<{ _id: string }, any, disableFilterHskOriginReqBody>,
+  res: Response
+) => {
+  const { _id } = req.params
+  const { state } = req.body
+  const currentDate = new Date()
+  const vietnamTimezoneOffset = 7 * 60
+  const localTime = new Date(currentDate.getTime() + vietnamTimezoneOffset * 60 * 1000)
+
+  const result = await databaseService.filterOrigin.findOneAndUpdate(
+    { _id: new ObjectId(_id) },
+    { $set: { state, updated_at: localTime } },
+    { returnDocument: 'after' }
+  )
+  res.json({ message: ADMIN_MESSAGES.UPDATE_FILTER_ORIGIN_STATE_SUCCESS, data: result })
+}
+
+export const searchFilterHskOriginsController = async (req: Request, res: Response, next: NextFunction) => {
+  const { keyword } = req.query
+  const filter: Filter<FilterHskOrigin> = {}
+  if (keyword) {
+    filter.option_name = { $regex: keyword as string, $options: 'i' }
+  }
+  await sendPaginatedResponse(res, next, databaseService.filterOrigin, req.query, filter)
+}

--- a/backend/src/controllers/filterHskProductType.controllers.ts
+++ b/backend/src/controllers/filterHskProductType.controllers.ts
@@ -13,6 +13,7 @@ import { getLocalTime } from '~/utils/date'
 import { Filter } from 'mongodb'
 import FilterHskProductType from '~/models/schemas/FilterHskProductType.schema'
 import { ADMIN_MESSAGES } from '~/constants/messages'
+import { GenericFilterState } from '~/constants/enums'
 
 export const getAllFilterHskProductTypesController = async (req: Request, res: Response, next: NextFunction) => {
   await sendPaginatedResponse(res, next, databaseService.filterHskProductType, req.query)
@@ -72,3 +73,15 @@ export const searchFilterHskProductTypesController = async (req: Request, res: R
   }
   await sendPaginatedResponse(res, next, databaseService.filterHskProductType, req.query, filter)
 }
+
+export const getActiveFilterHskProductTypesController = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const result = await databaseService.filterHskProductType.find({ state: GenericFilterState.ACTIVE }).toArray();
+    res.json({
+      message: ADMIN_MESSAGES.GET_ACTIVE_FILTER_PRODUCT_TYPES_SUCCESSFULLY,
+      data: result
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/src/controllers/filterHskSize.controllers.ts
+++ b/backend/src/controllers/filterHskSize.controllers.ts
@@ -13,6 +13,7 @@ import { getLocalTime } from '~/utils/date'
 import { Filter } from 'mongodb'
 import FilterHskSize from '~/models/schemas/FilterHskSize.schema'
 import { ADMIN_MESSAGES } from '~/constants/messages'
+import { GenericFilterState } from '~/constants/enums'
 
 export const getAllFilterHskSizesController = async (req: Request, res: Response, next: NextFunction) => {
   await sendPaginatedResponse(res, next, databaseService.filterHskSize, req.query)
@@ -72,3 +73,15 @@ export const searchFilterHskSizesController = async (req: Request, res: Response
   }
   await sendPaginatedResponse(res, next, databaseService.filterHskSize, req.query, filter)
 }
+
+export const getActiveFilterHskSizesController = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const result = await databaseService.filterHskSize.find({ state: GenericFilterState.ACTIVE }).toArray();
+    res.json({
+      message: ADMIN_MESSAGES.GET_ACTIVE_FILTER_SIZES_SUCCESSFULLY,
+      data: result
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/src/controllers/filterHskSkinType.controllers.ts
+++ b/backend/src/controllers/filterHskSkinType.controllers.ts
@@ -13,6 +13,7 @@ import { getLocalTime } from '~/utils/date'
 import { Filter } from 'mongodb'
 import FilterHskSkinType from '~/models/schemas/FilterHskSkinType.schema'
 import { ADMIN_MESSAGES } from '~/constants/messages'
+import { GenericFilterState } from '~/constants/enums'
 
 export const getAllFilterHskSkinTypesController = async (req: Request, res: Response, next: NextFunction) => {
   await sendPaginatedResponse(res, next, databaseService.filterHskSkinType, req.query)
@@ -72,3 +73,15 @@ export const searchFilterHskSkinTypesController = async (req: Request, res: Resp
   }
   await sendPaginatedResponse(res, next, databaseService.filterHskSkinType, req.query, filter)
 }
+
+export const getActiveFilterHskSkinTypesController = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const result = await databaseService.filterHskSkinType.find({ state: GenericFilterState.ACTIVE }).toArray();
+    res.json({
+      message: ADMIN_MESSAGES.GET_ACTIVE_FILTER_SKIN_TYPES_SUCCESSFULLY,
+      data: result
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/src/controllers/filterHskUses.controllers.ts
+++ b/backend/src/controllers/filterHskUses.controllers.ts
@@ -13,6 +13,7 @@ import { getLocalTime } from '~/utils/date'
 import { Filter } from 'mongodb'
 import FilterHskUses from '~/models/schemas/FilterHskUses.schema'
 import { ADMIN_MESSAGES } from '~/constants/messages'
+import { GenericFilterState } from '~/constants/enums'
 
 export const getAllFilterHskUsesController = async (req: Request, res: Response, next: NextFunction) => {
   await sendPaginatedResponse(res, next, databaseService.filterHskUses, req.query)
@@ -72,3 +73,15 @@ export const searchFilterHskUsesController = async (req: Request, res: Response,
   }
   await sendPaginatedResponse(res, next, databaseService.filterHskUses, req.query, filter)
 }
+
+export const getActiveFilterHskUsesController = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const result = await databaseService.filterHskUses.find({ state: GenericFilterState.ACTIVE }).toArray();
+    res.json({
+      message: ADMIN_MESSAGES.GET_ACTIVE_FILTER_USES_SUCCESSFULLY,
+      data: result
+    });
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/src/controllers/filterHskUses.controllers.ts
+++ b/backend/src/controllers/filterHskUses.controllers.ts
@@ -29,6 +29,11 @@ export const createNewFilterHskUsesController = async (
 export const getFilterHskUsesByIdController = async (req: Request<{ _id: string }>, res: Response) => {
   const { _id } = req.params
   const result = await databaseService.filterHskUses.findOne({ _id: new ObjectId(_id) })
+  if (!result) {
+    res.status(404).json({
+      message: ADMIN_MESSAGES.FILTER_USES_NOT_FOUND
+    })
+  }
   res.json({ data: result })
 }
 

--- a/backend/src/controllers/filterHskUses.controllers.ts
+++ b/backend/src/controllers/filterHskUses.controllers.ts
@@ -1,0 +1,69 @@
+import { Request, Response, NextFunction } from 'express'
+import { ParamsDictionary } from 'express-serve-static-core'
+import { sendPaginatedResponse } from '~/utils/pagination.helper'
+import databaseService from '~/services/database.services'
+import {
+  createNewFilterHskUsesReqBody,
+  disableFilterHskUsesReqBody,
+  updateFilterHskUsesReqBody
+} from '~/models/requests/Admin.requests'
+import filterHskUsesService from '~/services/filterHskUses.services'
+import { ObjectId } from 'mongodb'
+import { getLocalTime } from '~/utils/date'
+import { Filter } from 'mongodb'
+import FilterHskUses from '~/models/schemas/FilterHskUses.schema'
+import { ADMIN_MESSAGES } from '~/constants/messages'
+
+export const getAllFilterHskUsesController = async (req: Request, res: Response, next: NextFunction) => {
+  await sendPaginatedResponse(res, next, databaseService.filterHskUses, req.query)
+}
+
+export const createNewFilterHskUsesController = async (
+  req: Request<ParamsDictionary, any, createNewFilterHskUsesReqBody>,
+  res: Response
+) => {
+  const result = await filterHskUsesService.createNewFilterUses(req.body)
+  res.json({ message: ADMIN_MESSAGES.CREATE_NEW_FILTER_USES_SUCCESS, result })
+}
+
+export const getFilterHskUsesByIdController = async (req: Request<{ _id: string }>, res: Response) => {
+  const { _id } = req.params
+  const result = await databaseService.filterHskUses.findOne({ _id: new ObjectId(_id) })
+  res.json({ data: result })
+}
+
+export const updateFilterHskUsesController = async (
+  req: Request<{ _id: string }, any, updateFilterHskUsesReqBody>,
+  res: Response
+) => {
+  const { _id } = req.params
+  const result = await filterHskUsesService.updateFilterUses(_id, req.body)
+  res.json({ message: ADMIN_MESSAGES.UPDATE_FILTER_USES_SUCCESS, result })
+}
+
+export const disableFilterHskUsesController = async (
+  req: Request<{ _id: string }, any, disableFilterHskUsesReqBody>,
+  res: Response
+) => {
+  const { _id } = req.params
+  const { state } = req.body
+  const currentDate = new Date()
+  const vietnamTimezoneOffset = 7 * 60
+  const localTime = new Date(currentDate.getTime() + vietnamTimezoneOffset * 60 * 1000)
+
+  const result = await databaseService.filterHskUses.findOneAndUpdate(
+    { _id: new ObjectId(_id) },
+    { $set: { state, updated_at: localTime } },
+    { returnDocument: 'after' }
+  )
+  res.json({ message: ADMIN_MESSAGES.UPDATE_FILTER_USES_STATE_SUCCESS, data: result })
+}
+
+export const searchFilterHskUsesController = async (req: Request, res: Response, next: NextFunction) => {
+  const { keyword } = req.query
+  const filter: Filter<FilterHskUses> = {}
+  if (keyword) {
+    filter.option_name = { $regex: keyword as string, $options: 'i' }
+  }
+  await sendPaginatedResponse(res, next, databaseService.filterHskUses, req.query, filter)
+}

--- a/backend/src/docs/components/schemas/CreateFilterHskOriginReqBody.yaml
+++ b/backend/src/docs/components/schemas/CreateFilterHskOriginReqBody.yaml
@@ -1,0 +1,19 @@
+type: object
+required:
+  - option_name
+  - category_name
+  - category_param
+properties:
+  option_name:
+    type: string
+    example: 'Nhật Bản'
+  category_name:
+    type: string
+    example: 'Nguồn Gốc HSK'
+  category_param:
+    type: string
+    example: 'nhat-ban'
+  state:
+    type: string
+    enum: [INACTIVE, ACTIVE]
+    default: 'ACTIVE'

--- a/backend/src/docs/components/schemas/CreateFilterHskUsesReqBody.yaml
+++ b/backend/src/docs/components/schemas/CreateFilterHskUsesReqBody.yaml
@@ -1,0 +1,19 @@
+type: object
+required:
+  - option_name
+  - category_name
+  - category_param
+properties:
+  option_name:
+    type: string
+    example: 'Trị Mụn'
+  category_name:
+    type: string
+    example: 'Công Dụng HSK'
+  category_param:
+    type: string
+    example: 'tri-mun'
+  state:
+    type: string
+    enum: [INACTIVE, ACTIVE]
+    default: 'ACTIVE'

--- a/backend/src/docs/components/schemas/DisableFilterHskOriginReqBody.yaml
+++ b/backend/src/docs/components/schemas/DisableFilterHskOriginReqBody.yaml
@@ -1,0 +1,9 @@
+type: object
+required:
+  - state
+properties:
+  state:
+    type: string
+    description: 'Trạng thái mới cho filter nguồn gốc.'
+    enum: [INACTIVE, ACTIVE]
+    example: 'INACTIVE'

--- a/backend/src/docs/components/schemas/DisableFilterHskUsesReqBody.yaml
+++ b/backend/src/docs/components/schemas/DisableFilterHskUsesReqBody.yaml
@@ -1,0 +1,9 @@
+type: object
+required:
+  - state
+properties:
+  state:
+    type: string
+    description: 'Trạng thái mới cho filter công dụng.'
+    enum: [INACTIVE, ACTIVE]
+    example: 'INACTIVE'

--- a/backend/src/docs/components/schemas/FilterHskOrigin.yaml
+++ b/backend/src/docs/components/schemas/FilterHskOrigin.yaml
@@ -1,0 +1,24 @@
+type: object
+description: 'Đại diện cho một đối tượng filter Nguồn Gốc (Origin).'
+properties:
+  _id:
+    type: string
+    format: mongoId
+  option_name:
+    type: string
+    example: 'Hàn Quốc'
+  category_name:
+    type: string
+    example: 'Nguồn Gốc HSK'
+  category_param:
+    type: string
+    example: 'han-quoc'
+  state:
+    type: string
+    enum: [INACTIVE, ACTIVE]
+  created_at:
+    type: string
+    format: date-time
+  updated_at:
+    type: string
+    format: date-time

--- a/backend/src/docs/components/schemas/FilterHskUses.yaml
+++ b/backend/src/docs/components/schemas/FilterHskUses.yaml
@@ -1,0 +1,24 @@
+type: object
+description: 'Đại diện cho một đối tượng filter Công Dụng (Uses).'
+properties:
+  _id:
+    type: string
+    format: mongoId
+  option_name:
+    type: string
+    example: 'Phục Hồi Da'
+  category_name:
+    type: string
+    example: 'Công Dụng HSK'
+  category_param:
+    type: string
+    example: 'phuc-hoi-da'
+  state:
+    type: string
+    enum: [INACTIVE, ACTIVE]
+  created_at:
+    type: string
+    format: date-time
+  updated_at:
+    type: string
+    format: date-time

--- a/backend/src/docs/components/schemas/PaginatedFilterHskOriginResponse.yaml
+++ b/backend/src/docs/components/schemas/PaginatedFilterHskOriginResponse.yaml
@@ -1,0 +1,8 @@
+type: object
+properties:
+  data:
+    type: array
+    items:
+      $ref: './FilterHskOrigin.yaml'
+  pagination:
+    $ref: './Pagination.yaml'

--- a/backend/src/docs/components/schemas/PaginatedFilterHskUsesResponse.yaml
+++ b/backend/src/docs/components/schemas/PaginatedFilterHskUsesResponse.yaml
@@ -1,0 +1,8 @@
+type: object
+properties:
+  data:
+    type: array
+    items:
+      $ref: './FilterHskUses.yaml'
+  pagination:
+    $ref: './Pagination.yaml'

--- a/backend/src/docs/components/schemas/UpdateFilterHskOriginReqBody.yaml
+++ b/backend/src/docs/components/schemas/UpdateFilterHskOriginReqBody.yaml
@@ -1,0 +1,9 @@
+type: object
+description: 'Chỉ bao gồm các trường cần cập nhật cho nguồn gốc.'
+properties:
+  option_name:
+    type: string
+  category_name:
+    type: string
+  category_param:
+    type: string

--- a/backend/src/docs/components/schemas/UpdateFilterHskUsesReqBody.yaml
+++ b/backend/src/docs/components/schemas/UpdateFilterHskUsesReqBody.yaml
@@ -1,0 +1,9 @@
+type: object
+description: 'Chỉ bao gồm các trường cần cập nhật cho công dụng.'
+properties:
+  option_name:
+    type: string
+  category_name:
+    type: string
+  category_param:
+    type: string

--- a/backend/src/docs/openapi.yaml
+++ b/backend/src/docs/openapi.yaml
@@ -216,6 +216,17 @@ components:
       $ref: './components/schemas/DisableFilterHskSkinTypeReqBody.yaml'
     PaginatedFilterHskSkinTypeResponse:
       $ref: './components/schemas/PaginatedFilterHskSkinTypeResponse.yaml'
+    # FilterHskUses
+    FilterHskUses:
+      $ref: './components/schemas/FilterHskUses.yaml'
+    CreateFilterHskUsesReqBody:
+      $ref: './components/schemas/CreateFilterHskUsesReqBody.yaml'
+    UpdateFilterHskUsesReqBody:
+      $ref: './components/schemas/UpdateFilterHskUsesReqBody.yaml'
+    DisableFilterHskUsesReqBody:
+      $ref: './components/schemas/DisableFilterHskUsesReqBody.yaml'
+    PaginatedFilterHskUsesResponse:
+      $ref: './components/schemas/PaginatedFilterHskUsesResponse.yaml'
 
     # --- Response Schemas ---
     AuthSuccessResponse:

--- a/backend/src/docs/openapi.yaml
+++ b/backend/src/docs/openapi.yaml
@@ -227,6 +227,17 @@ components:
       $ref: './components/schemas/DisableFilterHskUsesReqBody.yaml'
     PaginatedFilterHskUsesResponse:
       $ref: './components/schemas/PaginatedFilterHskUsesResponse.yaml'
+    # FilterHskOrigin
+    FilterHskOrigin:
+      $ref: './components/schemas/FilterHskOrigin.yaml'
+    CreateFilterHskOriginReqBody:
+      $ref: './components/schemas/CreateFilterHskOriginReqBody.yaml'
+    UpdateFilterHskOriginReqBody:
+      $ref: './components/schemas/UpdateFilterHskOriginReqBody.yaml'
+    DisableFilterHskOriginReqBody:
+      $ref: './components/schemas/DisableFilterHskOriginReqBody.yaml'
+    PaginatedFilterHskOriginResponse:
+      $ref: './components/schemas/PaginatedFilterHskOriginResponse.yaml'
 
     # --- Response Schemas ---
     AuthSuccessResponse:

--- a/backend/src/docs/paths/all-paths.yaml
+++ b/backend/src/docs/paths/all-paths.yaml
@@ -2866,3 +2866,155 @@
               $ref: '../components/schemas/PaginatedFilterHskSkinTypeResponse.yaml'
       '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
       '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+
+/admin/manage-filters/create-new-filter-hsk-uses:
+  post:
+    tags: [Admin - Filter Uses]
+    summary: (Admin) Create a New HSK Uses Filter
+    security:
+      - BearerAuth: []
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/CreateFilterHskUsesReqBody.yaml'
+    responses:
+      '200':
+        description: Filter công dụng được tạo thành công.
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/MessageResponse.yaml'
+      '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '422': { $ref: '../components/schemas/ErrorValidationResponse.yaml' }
+
+/admin/manage-filters/get-all-filter-hsk-uses:
+  get:
+    tags: [Admin - Filter Uses]
+    summary: (Admin) Get All HSK Uses Filters
+    security:
+      - BearerAuth: []
+    parameters:
+      - $ref: '../openapi.yaml#/components/parameters/PageQuery'
+      - $ref: '../openapi.yaml#/components/parameters/LimitQuery'
+    responses:
+      '200':
+        description: Trả về danh sách các filter công dụng.
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/PaginatedFilterHskUsesResponse.yaml'
+      '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+
+/admin/manage-filters/get-filter-hsk-uses-detail/{_id}:
+  get:
+    tags: [Admin - Filter Uses]
+    summary: (Admin) Get HSK Uses Filter by ID
+    security:
+      - BearerAuth: []
+    parameters:
+      - name: _id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: mongoId
+    responses:
+      '200':
+        description: Chi tiết filter công dụng.
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/FilterHskUses.yaml'
+      '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '404': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+
+/admin/manage-filters/update-filter-hsk-uses/{_id}:
+  put:
+    tags: [Admin - Filter Uses]
+    summary: (Admin) Update an HSK Uses Filter
+    security:
+      - BearerAuth: []
+    parameters:
+      - name: _id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: mongoId
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/UpdateFilterHskUsesReqBody.yaml'
+    responses:
+      '200':
+        description: Filter công dụng được cập nhật thành công.
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/FilterHskUses.yaml'
+      '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '404': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '422': { $ref: '../components/schemas/ErrorValidationResponse.yaml' }
+
+/admin/manage-filters/update-filter-hsk-uses-state/{_id}:
+  put:
+    tags: [Admin - Filter Uses]
+    summary: (Admin) Update HSK Uses Filter State
+    security:
+      - BearerAuth: []
+    parameters:
+      - name: _id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: mongoId
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/DisableFilterHskUsesReqBody.yaml'
+    responses:
+      '200':
+        description: Trạng thái filter công dụng được cập nhật thành công.
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/FilterHskUses.yaml'
+      '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '404': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '422': { $ref: '../components/schemas/ErrorValidationResponse.yaml' }
+
+/admin/manage-filters/search-filter-hsk-uses:
+  get:
+    tags: [Admin - Filter Uses]
+    summary: (Admin) Search HSK Uses Filters by Name
+    security:
+      - BearerAuth: []
+    parameters:
+      - $ref: '../openapi.yaml#/components/parameters/PageQuery'
+      - $ref: '../openapi.yaml#/components/parameters/LimitQuery'
+      - name: keyword
+        in: query
+        description: Từ khóa tìm kiếm trong tên công dụng.
+        schema:
+          type: string
+    responses:
+      '200':
+        description: Trả về danh sách các filter công dụng phù hợp.
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/PaginatedFilterHskUsesResponse.yaml'
+      '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }

--- a/backend/src/docs/paths/all-paths.yaml
+++ b/backend/src/docs/paths/all-paths.yaml
@@ -3018,3 +3018,155 @@
               $ref: '../components/schemas/PaginatedFilterHskUsesResponse.yaml'
       '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
       '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+
+/admin/manage-filters/create-new-filter-hsk-origin:
+  post:
+    tags: [Admin - Filter Origin]
+    summary: (Admin) Create a New HSK Origin Filter
+    security:
+      - BearerAuth: []
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/CreateFilterHskOriginReqBody.yaml'
+    responses:
+      '200':
+        description: Filter nguồn gốc được tạo thành công.
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/MessageResponse.yaml'
+      '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '422': { $ref: '../components/schemas/ErrorValidationResponse.yaml' }
+
+/admin/manage-filters/get-all-filter-hsk-origins:
+  get:
+    tags: [Admin - Filter Origin]
+    summary: (Admin) Get All HSK Origin Filters
+    security:
+      - BearerAuth: []
+    parameters:
+      - $ref: '../openapi.yaml#/components/parameters/PageQuery'
+      - $ref: '../openapi.yaml#/components/parameters/LimitQuery'
+    responses:
+      '200':
+        description: Trả về danh sách các filter nguồn gốc.
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/PaginatedFilterHskOriginResponse.yaml'
+      '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+
+/admin/manage-filters/get-filter-hsk-origin-detail/{_id}:
+  get:
+    tags: [Admin - Filter Origin]
+    summary: (Admin) Get HSK Origin Filter by ID
+    security:
+      - BearerAuth: []
+    parameters:
+      - name: _id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: mongoId
+    responses:
+      '200':
+        description: Chi tiết filter nguồn gốc.
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/FilterHskOrigin.yaml'
+      '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '404': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+
+/admin/manage-filters/update-filter-hsk-origin/{_id}:
+  put:
+    tags: [Admin - Filter Origin]
+    summary: (Admin) Update an HSK Origin Filter
+    security:
+      - BearerAuth: []
+    parameters:
+      - name: _id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: mongoId
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/UpdateFilterHskOriginReqBody.yaml'
+    responses:
+      '200':
+        description: Filter nguồn gốc được cập nhật thành công.
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/FilterHskOrigin.yaml'
+      '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '404': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '422': { $ref: '../components/schemas/ErrorValidationResponse.yaml' }
+
+/admin/manage-filters/update-filter-hsk-origin-state/{_id}:
+  put:
+    tags: [Admin - Filter Origin]
+    summary: (Admin) Update HSK Origin Filter State
+    security:
+      - BearerAuth: []
+    parameters:
+      - name: _id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: mongoId
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/DisableFilterHskOriginReqBody.yaml'
+    responses:
+      '200':
+        description: Trạng thái filter nguồn gốc được cập nhật thành công.
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/FilterHskOrigin.yaml'
+      '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '404': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '422': { $ref: '../components/schemas/ErrorValidationResponse.yaml' }
+
+/admin/manage-filters/search-filter-hsk-origin:
+  get:
+    tags: [Admin - Filter Origin]
+    summary: (Admin) Search HSK Origin Filters by Name
+    security:
+      - BearerAuth: []
+    parameters:
+      - $ref: '../openapi.yaml#/components/parameters/PageQuery'
+      - $ref: '../openapi.yaml#/components/parameters/LimitQuery'
+      - name: keyword
+        in: query
+        description: Từ khóa tìm kiếm trong tên nguồn gốc.
+        schema:
+          type: string
+    responses:
+      '200':
+        description: Trả về danh sách các filter nguồn gốc phù hợp.
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/PaginatedFilterHskOriginResponse.yaml'
+      '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }

--- a/backend/src/docs/paths/all-paths.yaml
+++ b/backend/src/docs/paths/all-paths.yaml
@@ -1983,6 +1983,14 @@
           application/json:
             schema:
               $ref: '../components/schemas/FilterBrand.yaml'
+      '400':
+        description: Bad Request (VD:Cố gắng cập nhật một filter đang ở trạng thái không hoạt động).
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/ErrorStatusResponse.yaml'
+              example:
+                message: 'Cannot update an inactive filter. Please activate it first.'
       '401':
         $ref: '../components/schemas/ErrorStatusResponse.yaml'
       '403':
@@ -2164,6 +2172,14 @@
           application/json:
             schema:
               $ref: '../components/schemas/FilterDacTinh.yaml'
+      400':
+        description: Bad Request (VD:Cố gắng cập nhật một filter đang ở trạng thái không hoạt động).
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/ErrorStatusResponse.yaml'
+              example:
+                message: 'Cannot update an inactive filter. Please activate it first.'
       '401':
         $ref: '../components/schemas/ErrorStatusResponse.yaml'
       '403':
@@ -2340,6 +2356,14 @@
           application/json:
             schema:
               $ref: '../components/schemas/FilterHskIngredient.yaml'
+      400':
+        description: Bad Request (VD:Cố gắng cập nhật một filter đang ở trạng thái không hoạt động).
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/ErrorStatusResponse.yaml'
+              example:
+                message: 'Cannot update an inactive filter. Please activate it first.'
       '401':
         $ref: '../components/schemas/ErrorStatusResponse.yaml'
       '403':
@@ -2503,6 +2527,14 @@
           application/json:
             schema:
               $ref: '../components/schemas/FilterHskProductType.yaml'
+      400':
+        description: Bad Request (VD:Cố gắng cập nhật một filter đang ở trạng thái không hoạt động).
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/ErrorStatusResponse.yaml'
+              example:
+                message: 'Cannot update an inactive filter. Please activate it first.'
       '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
       '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
       '404': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
@@ -2655,6 +2687,14 @@
           application/json:
             schema:
               $ref: '../components/schemas/FilterHskSize.yaml'
+      400':
+        description: Bad Request (VD:Cố gắng cập nhật một filter đang ở trạng thái không hoạt động).
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/ErrorStatusResponse.yaml'
+              example:
+                message: 'Cannot update an inactive filter. Please activate it first.'
       '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
       '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
       '404': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
@@ -2807,6 +2847,14 @@
           application/json:
             schema:
               $ref: '../components/schemas/FilterHskSkinType.yaml'
+      400':
+        description: Bad Request (VD:Cố gắng cập nhật một filter đang ở trạng thái không hoạt động).
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/ErrorStatusResponse.yaml'
+              example:
+                message: 'Cannot update an inactive filter. Please activate it first.'
       '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
       '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
       '404': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
@@ -2959,6 +3007,14 @@
           application/json:
             schema:
               $ref: '../components/schemas/FilterHskUses.yaml'
+      400':
+        description: Bad Request (VD:Cố gắng cập nhật một filter đang ở trạng thái không hoạt động).
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/ErrorStatusResponse.yaml'
+              example:
+                message: 'Cannot update an inactive filter. Please activate it first.'
       '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
       '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
       '404': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
@@ -3111,6 +3167,14 @@
           application/json:
             schema:
               $ref: '../components/schemas/FilterHskOrigin.yaml'
+      400':
+        description: Bad Request (VD:Cố gắng cập nhật một filter đang ở trạng thái không hoạt động).
+        content:
+          application/json:
+            schema:
+              $ref: '../components/schemas/ErrorStatusResponse.yaml'
+              example:
+                message: 'Cannot update an inactive filter. Please activate it first.'
       '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
       '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
       '404': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }

--- a/backend/src/docs/paths/all-paths.yaml
+++ b/backend/src/docs/paths/all-paths.yaml
@@ -3170,3 +3170,187 @@
               $ref: '../components/schemas/PaginatedFilterHskOriginResponse.yaml'
       '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
       '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+
+/admin/manage-filters/get-active-filter-brands:
+  get:
+    tags: [Admin - Filter Brand]
+    summary: (Admin) Get All Active Filter Brands
+    description: Lấy danh sách tất cả các filter thương hiệu đang hoạt động để sử dụng trong việc tạo/cập nhật sản phẩm.
+    security:
+      - BearerAuth: []
+    responses:
+      '200':
+        description: Trả về một mảng các đối tượng filter thương hiệu.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message: { type: string, example: 'Get active filter brands successfully' }
+                data:
+                  type: array
+                  items:
+                    $ref: '../components/schemas/FilterBrand.yaml'
+      '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+
+/admin/manage-filters/get-active-filter-dac-tinhs:
+  get:
+    tags: [Admin - Filter Dac Tinh]
+    summary: (Admin) Get All Active Filter Dac Tinhs
+    description: Lấy danh sách tất cả các filter đặc tính đang hoạt động.
+    security:
+      - BearerAuth: []
+    responses:
+      '200':
+        description: Trả về một mảng các đối tượng filter đặc tính.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message: { type: string, example: 'Get active filter dac tinhs successfully' }
+                data:
+                  type: array
+                  items:
+                    $ref: '../components/schemas/FilterDacTinh.yaml'
+      '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+
+/admin/manage-filters/get-active-filter-hsk-ingredients:
+  get:
+    tags: [Admin - Filter Ingredient]
+    summary: (Admin) Get All Active HSK Ingredient Filters
+    description: Lấy danh sách tất cả các filter thành phần đang hoạt động.
+    security:
+      - BearerAuth: []
+    responses:
+      '200':
+        description: Trả về một mảng các đối tượng filter thành phần.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message: { type: string, example: 'Get active filter ingredients successfully' }
+                data:
+                  type: array
+                  items:
+                    $ref: '../components/schemas/FilterHskIngredient.yaml'
+      '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+
+/admin/manage-filters/get-active-filter-hsk-product-types:
+  get:
+    tags: [Admin - Filter Product Type]
+    summary: (Admin) Get All Active HSK Product Type Filters
+    description: Lấy danh sách tất cả các filter loại sản phẩm đang hoạt động.
+    security:
+      - BearerAuth: []
+    responses:
+      '200':
+        description: Trả về một mảng các đối tượng filter loại sản phẩm.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message: { type: string, example: 'Get active filter product types successfully' }
+                data:
+                  type: array
+                  items:
+                    $ref: '../components/schemas/FilterHskProductType.yaml'
+      '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+
+/admin/manage-filters/get-active-filter-hsk-sizes:
+  get:
+    tags: [Admin - Filter Size]
+    summary: (Admin) Get All Active HSK Size Filters
+    description: Lấy danh sách tất cả các filter kích thước đang hoạt động.
+    security:
+      - BearerAuth: []
+    responses:
+      '200':
+        description: Trả về một mảng các đối tượng filter kích thước.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message: { type: string, example: 'Get active filter sizes successfully' }
+                data:
+                  type: array
+                  items:
+                    $ref: '../components/schemas/FilterHskSize.yaml'
+      '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+
+/admin/manage-filters/get-active-filter-hsk-skin-types:
+  get:
+    tags: [Admin - Filter Skin Type]
+    summary: (Admin) Get All Active HSK Skin Type Filters
+    description: Lấy danh sách tất cả các filter loại da đang hoạt động.
+    security:
+      - BearerAuth: []
+    responses:
+      '200':
+        description: Trả về một mảng các đối tượng filter loại da.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message: { type: string, example: 'Get active filter skin types successfully' }
+                data:
+                  type: array
+                  items:
+                    $ref: '../components/schemas/FilterHskSkinType.yaml'
+      '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+
+/admin/manage-filters/get-active-filter-hsk-uses:
+  get:
+    tags: [Admin - Filter Uses]
+    summary: (Admin) Get All Active HSK Uses Filters
+    description: Lấy danh sách tất cả các filter công dụng đang hoạt động.
+    security:
+      - BearerAuth: []
+    responses:
+      '200':
+        description: Trả về một mảng các đối tượng filter công dụng.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message: { type: string, example: 'Get active filter uses successfully' }
+                data:
+                  type: array
+                  items:
+                    $ref: '../components/schemas/FilterHskUses.yaml'
+      '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+
+/admin/manage-filters/get-active-filter-hsk-origins:
+  get:
+    tags: [Admin - Filter Origin]
+    summary: (Admin) Get All Active HSK Origin Filters
+    description: Lấy danh sách tất cả các filter nguồn gốc đang hoạt động.
+    security:
+      - BearerAuth: []
+    responses:
+      '200':
+        description: Trả về một mảng các đối tượng filter nguồn gốc.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message: { type: string, example: 'Get active filter origins successfully' }
+                data:
+                  type: array
+                  items:
+                    $ref: '../components/schemas/FilterHskOrigin.yaml'
+      '401': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }
+      '403': { $ref: '../components/schemas/ErrorStatusResponse.yaml' }

--- a/backend/src/middlewares/admin.middlewares.ts
+++ b/backend/src/middlewares/admin.middlewares.ts
@@ -5,7 +5,7 @@ import { ErrorWithStatus } from '~/models/Errors'
 import databaseService from '~/services/database.services'
 import { Request, Response, NextFunction } from 'express'
 import { TokenPayLoad } from '~/models/requests/Users.requests'
-import { FilterBrandState, ProductState, Role, UserVerifyStatus } from '~/constants/enums'
+import { FilterBrandState, GenericFilterState, ProductState, Role, UserVerifyStatus } from '~/constants/enums'
 import { validate } from '~/utils/validation'
 import { ParamSchema, checkSchema } from 'express-validator'
 import filterBrandService from '~/services/filterBrand.services'
@@ -349,9 +349,24 @@ export const createNewProductValidator = validate(
             if (!value) {
               return true
             }
-            const isExist = await filterBrandService.checkBrandIdExist(value)
-            if (!isExist) {
+            // const isExist = await filterBrandService.checkBrandIdExist(value)
+            // if (!isExist) {
+            //   throw new Error(ADMIN_MESSAGES.BRAND_ID_NOT_FOUND)
+            // }
+            const brand = await databaseService.filterBrand.findOne({ _id: new ObjectId(value) })
+            if (!brand) {
               throw new Error(ADMIN_MESSAGES.BRAND_ID_NOT_FOUND)
+            }
+            //logic không thể tạo khi inactive brand
+            if (
+              [FilterBrandState.INACTIVE, FilterBrandState.SUSPENDED, FilterBrandState.DISCONTINUED].includes(
+                brand.state as FilterBrandState
+              )
+            ) {
+              throw new ErrorWithStatus({
+                message: ADMIN_MESSAGES.FILTER_BRAND_IS_INACTIVE,
+                status: HTTP_STATUS.BAD_REQUEST
+              })
             }
             return true
           }
@@ -366,13 +381,17 @@ export const createNewProductValidator = validate(
           options: (value) => (value === '' ? null : value)
         },
         custom: {
-          options: async (value, { req }) => {
-            if (!value) {
-              return true
-            }
-            const isExist = await filterDacTinhService.checkDacTinhIdExist(value)
-            if (!isExist) {
+          options: async (value) => {
+            if (!value) return true
+            const dacTinh = await databaseService.filterDacTinh.findOne({ _id: new ObjectId(value) })
+            if (!dacTinh) {
               throw new Error(ADMIN_MESSAGES.DAC_TINH_ID_NOT_FOUND)
+            }
+            if (dacTinh.state === GenericFilterState.INACTIVE) {
+              throw new ErrorWithStatus({
+                message: ADMIN_MESSAGES.FILTER_DAC_TINH_IS_INACTIVE,
+                status: HTTP_STATUS.BAD_REQUEST
+              })
             }
             return true
           }
@@ -387,13 +406,17 @@ export const createNewProductValidator = validate(
           options: (value) => (value === '' ? null : value)
         },
         custom: {
-          options: async (value, { req }) => {
-            if (!value) {
-              return true
-            }
-            const isExist = await filterHskIngredientService.checkIngredientIdExist(value)
-            if (!isExist) {
+          options: async (value) => {
+            if (!value) return true
+            const ingredient = await databaseService.filterHskIngredient.findOne({ _id: new ObjectId(value) })
+            if (!ingredient) {
               throw new Error(ADMIN_MESSAGES.INGREDIENT_ID_NOT_FOUND)
+            }
+            if (ingredient.state === GenericFilterState.INACTIVE) {
+              throw new ErrorWithStatus({
+                message: ADMIN_MESSAGES.FILTER_INGREDIENT_IS_INACTIVE,
+                status: HTTP_STATUS.BAD_REQUEST
+              })
             }
             return true
           }
@@ -408,13 +431,17 @@ export const createNewProductValidator = validate(
           options: (value) => (value === '' ? null : value)
         },
         custom: {
-          options: async (value, { req }) => {
-            if (!value) {
-              return true
-            }
-            const isExist = await filterHskProductTypeService.checkProductTypeIdExist(value)
-            if (!isExist) {
+          options: async (value) => {
+            if (!value) return true
+            const productType = await databaseService.filterHskProductType.findOne({ _id: new ObjectId(value) })
+            if (!productType) {
               throw new Error(ADMIN_MESSAGES.PRODUCT_TYPE_ID_NOT_FOUND)
+            }
+            if (productType.state === GenericFilterState.INACTIVE) {
+              throw new ErrorWithStatus({
+                message: ADMIN_MESSAGES.FILTER_PRODUCT_TYPE_IS_INACTIVE,
+                status: HTTP_STATUS.BAD_REQUEST
+              })
             }
             return true
           }
@@ -429,13 +456,17 @@ export const createNewProductValidator = validate(
           options: (value) => (value === '' ? null : value)
         },
         custom: {
-          options: async (value, { req }) => {
-            if (!value) {
-              return true
-            }
-            const isExist = await filterHskSizeService.checkSizeIdExist(value)
-            if (!isExist) {
+          options: async (value) => {
+            if (!value) return true
+            const size = await databaseService.filterHskSize.findOne({ _id: new ObjectId(value) })
+            if (!size) {
               throw new Error(ADMIN_MESSAGES.SIZE_ID_NOT_FOUND)
+            }
+            if (size.state === GenericFilterState.INACTIVE) {
+              throw new ErrorWithStatus({
+                message: ADMIN_MESSAGES.FILTER_SIZE_IS_INACTIVE,
+                status: HTTP_STATUS.BAD_REQUEST
+              })
             }
             return true
           }
@@ -450,13 +481,17 @@ export const createNewProductValidator = validate(
           options: (value) => (value === '' ? null : value)
         },
         custom: {
-          options: async (value, { req }) => {
-            if (!value) {
-              return true
-            }
-            const isExist = await filterHskSkinTypeService.checkSkinTypeIdExist(value)
-            if (!isExist) {
+          options: async (value) => {
+            if (!value) return true
+            const skinType = await databaseService.filterHskSkinType.findOne({ _id: new ObjectId(value) })
+            if (!skinType) {
               throw new Error(ADMIN_MESSAGES.SKIN_TYPE_ID_NOT_FOUND)
+            }
+            if (skinType.state === GenericFilterState.INACTIVE) {
+              throw new ErrorWithStatus({
+                message: ADMIN_MESSAGES.FILTER_SKIN_TYPE_IS_INACTIVE,
+                status: HTTP_STATUS.BAD_REQUEST
+              })
             }
             return true
           }
@@ -471,13 +506,17 @@ export const createNewProductValidator = validate(
           options: (value) => (value === '' ? null : value)
         },
         custom: {
-          options: async (value, { req }) => {
-            if (!value) {
-              return true
-            }
-            const isExist = await filterHskUsesService.checkUsesIdExist(value)
-            if (!isExist) {
+          options: async (value) => {
+            if (!value) return true
+            const uses = await databaseService.filterHskUses.findOne({ _id: new ObjectId(value) })
+            if (!uses) {
               throw new Error(ADMIN_MESSAGES.USES_ID_NOT_FOUND)
+            }
+            if (uses.state === GenericFilterState.INACTIVE) {
+              throw new ErrorWithStatus({
+                message: ADMIN_MESSAGES.FILTER_USES_IS_INACTIVE,
+                status: HTTP_STATUS.BAD_REQUEST
+              })
             }
             return true
           }
@@ -492,13 +531,17 @@ export const createNewProductValidator = validate(
           options: (value) => (value === '' ? null : value)
         },
         custom: {
-          options: async (value, { req }) => {
-            if (!value) {
-              return true
-            }
-            const isExist = await filterOriginService.checkOriginIdExist(value)
-            if (!isExist) {
+          options: async (value) => {
+            if (!value) return true
+            const origin = await databaseService.filterOrigin.findOne({ _id: new ObjectId(value) })
+            if (!origin) {
               throw new Error(ADMIN_MESSAGES.ORIGIN_ID_NOT_FOUND)
+            }
+            if (origin.state === GenericFilterState.INACTIVE) {
+              throw new ErrorWithStatus({
+                message: ADMIN_MESSAGES.FILTER_ORIGIN_IS_INACTIVE,
+                status: HTTP_STATUS.BAD_REQUEST
+              })
             }
             return true
           }
@@ -811,13 +854,31 @@ export const updateProductValidator = validate(
           options: (value) => (value === '' ? null : value)
         },
         custom: {
-          options: async (value, { req }) => {
-            if (!value) {
-              return true
-            }
-            const isExist = await filterBrandService.checkBrandIdExist(value)
-            if (!isExist) {
+          // options: async (value, { req }) => {
+          //   if (!value) {
+          //     return true
+          //   }
+          //   const isExist = await filterBrandService.checkBrandIdExist(value)
+          //   if (!isExist) {
+          //     throw new Error(ADMIN_MESSAGES.BRAND_ID_NOT_FOUND)
+          //   }
+          //   return true
+          // }
+          options: async (value) => {
+            if (!value) return true
+            const brand = await databaseService.filterBrand.findOne({ _id: new ObjectId(value) })
+            if (!brand) {
               throw new Error(ADMIN_MESSAGES.BRAND_ID_NOT_FOUND)
+            }
+            if (
+              [FilterBrandState.INACTIVE, FilterBrandState.SUSPENDED, FilterBrandState.DISCONTINUED].includes(
+                brand.state as FilterBrandState
+              )
+            ) {
+              throw new ErrorWithStatus({
+                message: ADMIN_MESSAGES.FILTER_BRAND_IS_INACTIVE,
+                status: HTTP_STATUS.BAD_REQUEST
+              })
             }
             return true
           }
@@ -832,13 +893,27 @@ export const updateProductValidator = validate(
           options: (value) => (value === '' ? null : value)
         },
         custom: {
-          options: async (value, { req }) => {
-            if (!value) {
-              return true
-            }
-            const isExist = await filterDacTinhService.checkDacTinhIdExist(value)
-            if (!isExist) {
+          // options: async (value, { req }) => {
+          //   if (!value) {
+          //     return true
+          //   }
+          //   const isExist = await filterDacTinhService.checkDacTinhIdExist(value)
+          //   if (!isExist) {
+          //     throw new Error(ADMIN_MESSAGES.DAC_TINH_ID_NOT_FOUND)
+          //   }
+          //   return true
+          // }
+          options: async (value) => {
+            if (!value) return true
+            const dacTinh = await databaseService.filterDacTinh.findOne({ _id: new ObjectId(value) })
+            if (!dacTinh) {
               throw new Error(ADMIN_MESSAGES.DAC_TINH_ID_NOT_FOUND)
+            }
+            if (dacTinh.state === GenericFilterState.INACTIVE) {
+              throw new ErrorWithStatus({
+                message: ADMIN_MESSAGES.FILTER_DAC_TINH_IS_INACTIVE,
+                status: HTTP_STATUS.BAD_REQUEST
+              })
             }
             return true
           }
@@ -853,13 +928,27 @@ export const updateProductValidator = validate(
           options: (value) => (value === '' ? null : value)
         },
         custom: {
-          options: async (value, { req }) => {
-            if (!value) {
-              return true
-            }
-            const isExist = await filterHskIngredientService.checkIngredientIdExist(value)
-            if (!isExist) {
+          // options: async (value, { req }) => {
+          //   if (!value) {
+          //     return true
+          //   }
+          //   const isExist = await filterHskIngredientService.checkIngredientIdExist(value)
+          //   if (!isExist) {
+          //     throw new Error(ADMIN_MESSAGES.INGREDIENT_ID_NOT_FOUND)
+          //   }
+          //   return true
+          // }
+          options: async (value) => {
+            if (!value) return true
+            const ingredient = await databaseService.filterHskIngredient.findOne({ _id: new ObjectId(value) })
+            if (!ingredient) {
               throw new Error(ADMIN_MESSAGES.INGREDIENT_ID_NOT_FOUND)
+            }
+            if (ingredient.state === GenericFilterState.INACTIVE) {
+              throw new ErrorWithStatus({
+                message: ADMIN_MESSAGES.FILTER_INGREDIENT_IS_INACTIVE,
+                status: HTTP_STATUS.BAD_REQUEST
+              })
             }
             return true
           }
@@ -874,13 +963,27 @@ export const updateProductValidator = validate(
           options: (value) => (value === '' ? null : value)
         },
         custom: {
-          options: async (value, { req }) => {
-            if (!value) {
-              return true
-            }
-            const isExist = await filterHskProductTypeService.checkProductTypeIdExist(value)
-            if (!isExist) {
+          // options: async (value, { req }) => {
+          //   if (!value) {
+          //     return true
+          //   }
+          //   const isExist = await filterHskProductTypeService.checkProductTypeIdExist(value)
+          //   if (!isExist) {
+          //     throw new Error(ADMIN_MESSAGES.PRODUCT_TYPE_ID_NOT_FOUND)
+          //   }
+          //   return true
+          // }
+          options: async (value) => {
+            if (!value) return true
+            const productType = await databaseService.filterHskProductType.findOne({ _id: new ObjectId(value) })
+            if (!productType) {
               throw new Error(ADMIN_MESSAGES.PRODUCT_TYPE_ID_NOT_FOUND)
+            }
+            if (productType.state === GenericFilterState.INACTIVE) {
+              throw new ErrorWithStatus({
+                message: ADMIN_MESSAGES.FILTER_PRODUCT_TYPE_IS_INACTIVE,
+                status: HTTP_STATUS.BAD_REQUEST
+              })
             }
             return true
           }
@@ -895,13 +998,27 @@ export const updateProductValidator = validate(
           options: (value) => (value === '' ? null : value)
         },
         custom: {
-          options: async (value, { req }) => {
-            if (!value) {
-              return true
-            }
-            const isExist = await filterHskSizeService.checkSizeIdExist(value)
-            if (!isExist) {
+          // options: async (value, { req }) => {
+          //   if (!value) {
+          //     return true
+          //   }
+          //   const isExist = await filterHskSizeService.checkSizeIdExist(value)
+          //   if (!isExist) {
+          //     throw new Error(ADMIN_MESSAGES.SIZE_ID_NOT_FOUND)
+          //   }
+          //   return true
+          // }
+          options: async (value) => {
+            if (!value) return true
+            const size = await databaseService.filterHskSize.findOne({ _id: new ObjectId(value) })
+            if (!size) {
               throw new Error(ADMIN_MESSAGES.SIZE_ID_NOT_FOUND)
+            }
+            if (size.state === GenericFilterState.INACTIVE) {
+              throw new ErrorWithStatus({
+                message: ADMIN_MESSAGES.FILTER_SIZE_IS_INACTIVE,
+                status: HTTP_STATUS.BAD_REQUEST
+              })
             }
             return true
           }
@@ -916,13 +1033,17 @@ export const updateProductValidator = validate(
           options: (value) => (value === '' ? null : value)
         },
         custom: {
-          options: async (value, { req }) => {
-            if (!value) {
-              return true
-            }
-            const isExist = await filterHskSkinTypeService.checkSkinTypeIdExist(value)
-            if (!isExist) {
+          options: async (value) => {
+            if (!value) return true
+            const skinType = await databaseService.filterHskSkinType.findOne({ _id: new ObjectId(value) })
+            if (!skinType) {
               throw new Error(ADMIN_MESSAGES.SKIN_TYPE_ID_NOT_FOUND)
+            }
+            if (skinType.state === GenericFilterState.INACTIVE) {
+              throw new ErrorWithStatus({
+                message: ADMIN_MESSAGES.FILTER_SKIN_TYPE_IS_INACTIVE,
+                status: HTTP_STATUS.BAD_REQUEST
+              })
             }
             return true
           }
@@ -937,13 +1058,27 @@ export const updateProductValidator = validate(
           options: (value) => (value === '' ? null : value)
         },
         custom: {
-          options: async (value, { req }) => {
-            if (!value) {
-              return true
-            }
-            const isExist = await filterHskUsesService.checkUsesIdExist(value)
-            if (!isExist) {
+          // options: async (value, { req }) => {
+          //   if (!value) {
+          //     return true
+          //   }
+          //   const isExist = await filterHskUsesService.checkUsesIdExist(value)
+          //   if (!isExist) {
+          //     throw new Error(ADMIN_MESSAGES.USES_ID_NOT_FOUND)
+          //   }
+          //   return true
+          // }
+          options: async (value) => {
+            if (!value) return true
+            const uses = await databaseService.filterHskUses.findOne({ _id: new ObjectId(value) })
+            if (!uses) {
               throw new Error(ADMIN_MESSAGES.USES_ID_NOT_FOUND)
+            }
+            if (uses.state === GenericFilterState.INACTIVE) {
+              throw new ErrorWithStatus({
+                message: ADMIN_MESSAGES.FILTER_USES_IS_INACTIVE,
+                status: HTTP_STATUS.BAD_REQUEST
+              })
             }
             return true
           }
@@ -958,13 +1093,27 @@ export const updateProductValidator = validate(
           options: (value) => (value === '' ? null : value)
         },
         custom: {
-          options: async (value, { req }) => {
-            if (!value) {
-              return true
-            }
-            const isExist = await filterOriginService.checkOriginIdExist(value)
-            if (!isExist) {
+          // options: async (value, { req }) => {
+          //   if (!value) {
+          //     return true
+          //   }
+          //   const isExist = await filterOriginService.checkOriginIdExist(value)
+          //   if (!isExist) {
+          //     throw new Error(ADMIN_MESSAGES.ORIGIN_ID_NOT_FOUND)
+          //   }
+          //   return true
+          // }
+          options: async (value) => {
+            if (!value) return true
+            const origin = await databaseService.filterOrigin.findOne({ _id: new ObjectId(value) })
+            if (!origin) {
               throw new Error(ADMIN_MESSAGES.ORIGIN_ID_NOT_FOUND)
+            }
+            if (origin.state === GenericFilterState.INACTIVE) {
+              throw new ErrorWithStatus({
+                message: ADMIN_MESSAGES.FILTER_ORIGIN_IS_INACTIVE,
+                status: HTTP_STATUS.BAD_REQUEST
+              })
             }
             return true
           }

--- a/backend/src/middlewares/filterDacTinh.middlewares.ts
+++ b/backend/src/middlewares/filterDacTinh.middlewares.ts
@@ -40,7 +40,28 @@ export const createNewFilterDacTinhValidator = validate(
 
 export const updateFilterDacTinhValidator = validate(
   checkSchema({
-    _id: { in: ['params'], isMongoId: { errorMessage: ADMIN_MESSAGES.FILTER_DAC_TINH_ID_IS_INVALID } },
+    _id: {
+      in: ['params'],
+      isMongoId: { errorMessage: ADMIN_MESSAGES.FILTER_DAC_TINH_ID_IS_INVALID },
+      custom: {
+        options: async (value) => {
+          const dacTinh = await databaseService.filterDacTinh.findOne({ _id: new ObjectId(value) })
+          if (!dacTinh) {
+            throw new ErrorWithStatus({
+              message: ADMIN_MESSAGES.FILTER_DAC_TINH_NOT_FOUND,
+              status: HTTP_STATUS.NOT_FOUND
+            })
+          }
+          if (dacTinh.state === GenericFilterState.INACTIVE) {
+            throw new ErrorWithStatus({
+              message: ADMIN_MESSAGES.FILTER_IS_INACTIVE_CANNOT_UPDATE,
+              status: HTTP_STATUS.BAD_REQUEST
+            })
+          }
+          return true
+        }
+      }
+    },
     option_name: {
       optional: true,
       isString: {

--- a/backend/src/middlewares/filterHskOrigin.middlewares.ts
+++ b/backend/src/middlewares/filterHskOrigin.middlewares.ts
@@ -1,0 +1,99 @@
+// src/middlewares/filterHskOrigin.middlewares.ts
+
+import { validate } from '~/utils/validation'
+import { checkSchema } from 'express-validator'
+import { GenericFilterState } from '~/constants/enums'
+import { ObjectId } from 'mongodb'
+import databaseService from '~/services/database.services'
+import { ErrorWithStatus } from '~/models/Errors'
+import HTTP_STATUS from '~/constants/httpStatus'
+import { ADMIN_MESSAGES } from '~/constants/messages'
+
+export const createNewFilterHskOriginValidator = validate(
+  checkSchema(
+    {
+      option_name: {
+        notEmpty: { errorMessage: ADMIN_MESSAGES.FILTER_ORIGIN_OPTION_NAME_IS_REQUIRED },
+        isString: { errorMessage: ADMIN_MESSAGES.FILTER_ORIGIN_OPTION_NAME_MUST_BE_STRING },
+        trim: true
+      },
+      category_name: {
+        notEmpty: { errorMessage: ADMIN_MESSAGES.FILTER_ORIGIN_CATEGORY_NAME_IS_REQUIRED },
+        isString: { errorMessage: ADMIN_MESSAGES.FILTER_ORIGIN_CATEGORY_NAME_MUST_BE_STRING },
+        trim: true
+      },
+      category_param: {
+        notEmpty: { errorMessage: ADMIN_MESSAGES.FILTER_ORIGIN_CATEGORY_PARAM_IS_REQUIRED },
+        isString: { errorMessage: ADMIN_MESSAGES.FILTER_ORIGIN_CATEGORY_PARAM_MUST_BE_STRING },
+        trim: true
+      },
+      state: {
+        optional: true,
+        isString: { errorMessage: ADMIN_MESSAGES.FILTER_ORIGIN_STATE_MUST_BE_A_STRING },
+        isIn: {
+          options: [Object.values(GenericFilterState)],
+          errorMessage: `State must be one of: ${Object.values(GenericFilterState).join(', ')}`
+        }
+      }
+    },
+    ['body']
+  )
+)
+
+export const updateFilterHskOriginValidator = validate(
+  checkSchema({
+    _id: { in: ['params'], isMongoId: { errorMessage: ADMIN_MESSAGES.FILTER_ORIGIN_ID_IS_INVALID } },
+    option_name: {
+      optional: true,
+      isString: { errorMessage: ADMIN_MESSAGES.FILTER_ORIGIN_OPTION_NAME_MUST_BE_STRING },
+      trim: true
+    },
+    category_name: {
+      optional: true,
+      isString: { errorMessage: ADMIN_MESSAGES.FILTER_ORIGIN_CATEGORY_NAME_MUST_BE_STRING },
+      trim: true
+    },
+    category_param: {
+      optional: true,
+      isString: { errorMessage: ADMIN_MESSAGES.FILTER_ORIGIN_CATEGORY_PARAM_MUST_BE_STRING },
+      trim: true
+    }
+  })
+)
+
+export const disableFilterHskOriginValidator = validate(
+  checkSchema({
+    _id: { in: ['params'], isMongoId: { errorMessage: ADMIN_MESSAGES.FILTER_ORIGIN_ID_IS_INVALID } },
+    state: {
+      in: ['body'],
+      isIn: {
+        options: [Object.values(GenericFilterState)],
+        errorMessage: `State must be one of: ${Object.values(GenericFilterState).join(', ')}`
+      }
+    }
+  })
+)
+
+export const getFilterHskOriginByIdValidator = validate(
+  checkSchema(
+    {
+      _id: {
+        in: ['params'],
+        isMongoId: { errorMessage: ADMIN_MESSAGES.FILTER_ORIGIN_ID_IS_INVALID },
+        custom: {
+          options: async (value) => {
+            const origin = await databaseService.filterOrigin.findOne({ _id: new ObjectId(value) })
+            if (!origin) {
+              throw new ErrorWithStatus({
+                message: ADMIN_MESSAGES.FILTER_ORIGIN_NOT_FOUND,
+                status: HTTP_STATUS.NOT_FOUND
+              })
+            }
+            return true
+          }
+        }
+      }
+    },
+    ['params']
+  )
+)

--- a/backend/src/middlewares/filterHskOrigin.middlewares.ts
+++ b/backend/src/middlewares/filterHskOrigin.middlewares.ts
@@ -42,7 +42,28 @@ export const createNewFilterHskOriginValidator = validate(
 
 export const updateFilterHskOriginValidator = validate(
   checkSchema({
-    _id: { in: ['params'], isMongoId: { errorMessage: ADMIN_MESSAGES.FILTER_ORIGIN_ID_IS_INVALID } },
+    _id: {
+      in: ['params'],
+      isMongoId: { errorMessage: ADMIN_MESSAGES.FILTER_ORIGIN_ID_IS_INVALID },
+      custom: {
+        options: async (value) => {
+          const origin = await databaseService.filterOrigin.findOne({ _id: new ObjectId(value) })
+          if (!origin) {
+            throw new ErrorWithStatus({
+              message: ADMIN_MESSAGES.FILTER_ORIGIN_NOT_FOUND,
+              status: HTTP_STATUS.NOT_FOUND
+            })
+          }
+          if (origin.state === GenericFilterState.INACTIVE) {
+            throw new ErrorWithStatus({
+              message: ADMIN_MESSAGES.FILTER_IS_INACTIVE_CANNOT_UPDATE,
+              status: HTTP_STATUS.BAD_REQUEST
+            })
+          }
+          return true
+        }
+      }
+    },
     option_name: {
       optional: true,
       isString: { errorMessage: ADMIN_MESSAGES.FILTER_ORIGIN_OPTION_NAME_MUST_BE_STRING },

--- a/backend/src/middlewares/filterHskProductType.middlewares.ts
+++ b/backend/src/middlewares/filterHskProductType.middlewares.ts
@@ -45,7 +45,28 @@ export const createNewFilterHskProductTypeValidator = validate(
 
 export const updateFilterHskProductTypeValidator = validate(
   checkSchema({
-    _id: { in: ['params'], isMongoId: { errorMessage: 'ID không hợp lệ' } },
+    _id: {
+      in: ['params'],
+      isMongoId: { errorMessage: ADMIN_MESSAGES.FILTER_PRODUCT_TYPE_ID_IS_INVALID },
+      custom: {
+        options: async (value) => {
+          const productType = await databaseService.filterHskProductType.findOne({ _id: new ObjectId(value) })
+          if (!productType) {
+            throw new ErrorWithStatus({
+              message: ADMIN_MESSAGES.FILTER_PRODUCT_TYPE_NOT_FOUND,
+              status: HTTP_STATUS.NOT_FOUND
+            })
+          }
+          if (productType.state === GenericFilterState.INACTIVE) {
+            throw new ErrorWithStatus({
+              message: ADMIN_MESSAGES.FILTER_IS_INACTIVE_CANNOT_UPDATE,
+              status: HTTP_STATUS.BAD_REQUEST
+            })
+          }
+          return true
+        }
+      }
+    },
     option_name: {
       optional: true,
       isString: { errorMessage: ADMIN_MESSAGES.FILTER_PRODUCT_TYPE_OPTION_NAME_MUST_BE_STRING },

--- a/backend/src/middlewares/filterHskSize.middlewares.ts
+++ b/backend/src/middlewares/filterHskSize.middlewares.ts
@@ -40,7 +40,25 @@ export const createNewFilterHskSizeValidator = validate(
 
 export const updateFilterHskSizeValidator = validate(
   checkSchema({
-    _id: { in: ['params'], isMongoId: { errorMessage: ADMIN_MESSAGES.FILTER_SIZE_ID_IS_INVALID } },
+    _id: {
+      in: ['params'],
+      isMongoId: { errorMessage: ADMIN_MESSAGES.FILTER_SIZE_ID_IS_INVALID },
+      custom: {
+        options: async (value) => {
+          const size = await databaseService.filterHskSize.findOne({ _id: new ObjectId(value) })
+          if (!size) {
+            throw new ErrorWithStatus({ message: ADMIN_MESSAGES.FILTER_SIZE_NOT_FOUND, status: HTTP_STATUS.NOT_FOUND })
+          }
+          if (size.state === GenericFilterState.INACTIVE) {
+            throw new ErrorWithStatus({
+              message: ADMIN_MESSAGES.FILTER_IS_INACTIVE_CANNOT_UPDATE,
+              status: HTTP_STATUS.BAD_REQUEST
+            })
+          }
+          return true
+        }
+      }
+    },
     option_name: {
       optional: true,
       isString: { errorMessage: ADMIN_MESSAGES.FILTER_SIZE_OPTION_NAME_MUST_BE_STRING },

--- a/backend/src/middlewares/filterHskSkinType.middlewares.ts
+++ b/backend/src/middlewares/filterHskSkinType.middlewares.ts
@@ -40,7 +40,28 @@ export const createNewFilterHskSkinTypeValidator = validate(
 
 export const updateFilterHskSkinTypeValidator = validate(
   checkSchema({
-    _id: { in: ['params'], isMongoId: { errorMessage: ADMIN_MESSAGES.FILTER_SKIN_TYPE_ID_IS_INVALID } },
+    _id: {
+      in: ['params'],
+      isMongoId: { errorMessage: ADMIN_MESSAGES.FILTER_SKIN_TYPE_ID_IS_INVALID },
+      custom: {
+        options: async (value) => {
+          const skinType = await databaseService.filterHskSkinType.findOne({ _id: new ObjectId(value) })
+          if (!skinType) {
+            throw new ErrorWithStatus({
+              message: ADMIN_MESSAGES.FILTER_SKIN_TYPE_NOT_FOUND,
+              status: HTTP_STATUS.NOT_FOUND
+            })
+          }
+          if (skinType.state === GenericFilterState.INACTIVE) {
+            throw new ErrorWithStatus({
+              message: ADMIN_MESSAGES.FILTER_IS_INACTIVE_CANNOT_UPDATE,
+              status: HTTP_STATUS.BAD_REQUEST
+            })
+          }
+          return true
+        }
+      }
+    },
     option_name: {
       optional: true,
       isString: { errorMessage: ADMIN_MESSAGES.FILTER_SKIN_TYPE_OPTION_NAME_MUST_BE_STRING },

--- a/backend/src/middlewares/filterHskUses.middlewares.ts
+++ b/backend/src/middlewares/filterHskUses.middlewares.ts
@@ -1,0 +1,97 @@
+import { validate } from '~/utils/validation'
+import { checkSchema } from 'express-validator'
+import { GenericFilterState } from '~/constants/enums'
+import { ObjectId } from 'mongodb'
+import databaseService from '~/services/database.services'
+import { ErrorWithStatus } from '~/models/Errors'
+import HTTP_STATUS from '~/constants/httpStatus'
+import { ADMIN_MESSAGES } from '~/constants/messages'
+
+export const createNewFilterHskUsesValidator = validate(
+  checkSchema(
+    {
+      option_name: {
+        notEmpty: { errorMessage: ADMIN_MESSAGES.FILTER_USES_OPTION_NAME_IS_REQUIRED },
+        isString: { errorMessage: ADMIN_MESSAGES.FILTER_USES_OPTION_NAME_MUST_BE_STRING },
+        trim: true
+      },
+      category_name: {
+        notEmpty: { errorMessage: ADMIN_MESSAGES.FILTER_USES_CATEGORY_NAME_IS_REQUIRED },
+        isString: { errorMessage: ADMIN_MESSAGES.FILTER_USES_CATEGORY_NAME_MUST_BE_STRING },
+        trim: true
+      },
+      category_param: {
+        notEmpty: { errorMessage: ADMIN_MESSAGES.FILTER_USES_CATEGORY_PARAM_IS_REQUIRED },
+        isString: { errorMessage: ADMIN_MESSAGES.FILTER_USES_CATEGORY_PARAM_MUST_BE_STRING },
+        trim: true
+      },
+      state: {
+        optional: true,
+        isString: { errorMessage: ADMIN_MESSAGES.FILTER_USES_STATE_MUST_BE_A_STRING },
+        isIn: {
+          options: [Object.values(GenericFilterState)],
+          errorMessage: `Trạng thái phải là một trong các giá trị: ${Object.values(GenericFilterState).join(', ')}`
+        }
+      }
+    },
+    ['body']
+  )
+)
+
+export const updateFilterHskUsesValidator = validate(
+  checkSchema({
+    _id: { in: ['params'], isMongoId: { errorMessage: ADMIN_MESSAGES.FILTER_USES_ID_IS_INVALID } },
+    option_name: {
+      optional: true,
+      isString: { errorMessage: ADMIN_MESSAGES.FILTER_USES_OPTION_NAME_MUST_BE_STRING },
+      trim: true
+    },
+    category_name: {
+      optional: true,
+      isString: { errorMessage: ADMIN_MESSAGES.FILTER_USES_CATEGORY_NAME_MUST_BE_STRING },
+      trim: true
+    },
+    category_param: {
+      optional: true,
+      isString: { errorMessage: ADMIN_MESSAGES.FILTER_USES_CATEGORY_PARAM_MUST_BE_STRING },
+      trim: true
+    }
+  })
+)
+
+export const disableFilterHskUsesValidator = validate(
+  checkSchema({
+    _id: { in: ['params'], isMongoId: { errorMessage: ADMIN_MESSAGES.FILTER_USES_ID_IS_INVALID } },
+    state: {
+      in: ['body'],
+      isIn: {
+        options: [Object.values(GenericFilterState)],
+        errorMessage: `Trạng thái phải là một trong các giá trị: ${Object.values(GenericFilterState).join(', ')}`
+      }
+    }
+  })
+)
+
+export const getFilterHskUsesByIdValidator = validate(
+  checkSchema(
+    {
+      _id: {
+        in: ['params'],
+        isMongoId: { errorMessage: ADMIN_MESSAGES.FILTER_USES_ID_IS_INVALID },
+        custom: {
+          options: async (value) => {
+            const uses = await databaseService.filterHskUses.findOne({ _id: new ObjectId(value) })
+            if (!uses) {
+              throw new ErrorWithStatus({
+                message: ADMIN_MESSAGES.FILTER_USES_NOT_FOUND,
+                status: HTTP_STATUS.NOT_FOUND
+              })
+            }
+            return true
+          }
+        }
+      }
+    },
+    ['params']
+  )
+)

--- a/backend/src/models/requests/Admin.requests.ts
+++ b/backend/src/models/requests/Admin.requests.ts
@@ -112,3 +112,20 @@ export interface updateFilterHskSkinTypeReqBody {
 export interface disableFilterHskSkinTypeReqBody {
   state: GenericFilterState
 }
+
+export interface createNewFilterHskUsesReqBody {
+  option_name: string
+  category_name: string
+  category_param: string
+  state?: GenericFilterState
+}
+
+export interface updateFilterHskUsesReqBody {
+  option_name?: string
+  category_name?: string
+  category_param?: string
+}
+
+export interface disableFilterHskUsesReqBody {
+  state: GenericFilterState
+}

--- a/backend/src/models/requests/Admin.requests.ts
+++ b/backend/src/models/requests/Admin.requests.ts
@@ -129,3 +129,20 @@ export interface updateFilterHskUsesReqBody {
 export interface disableFilterHskUsesReqBody {
   state: GenericFilterState
 }
+
+export interface createNewFilterHskOriginReqBody {
+  option_name: string
+  category_name: string
+  category_param: string
+  state?: GenericFilterState
+}
+
+export interface updateFilterHskOriginReqBody {
+  option_name?: string
+  category_name?: string
+  category_param?: string
+}
+
+export interface disableFilterHskOriginReqBody {
+  state: GenericFilterState
+}

--- a/backend/src/models/schemas/FilterHskOrigin.schema.ts
+++ b/backend/src/models/schemas/FilterHskOrigin.schema.ts
@@ -1,10 +1,14 @@
 import { ObjectId } from 'mongodb'
+import { GenericFilterState } from '~/constants/enums'
 
 interface FilterOriginType {
   _id?: ObjectId
   option_name?: string
   category_name?: string
   category_param?: string
+  state?: GenericFilterState
+  created_at?: Date
+  updated_at?: Date
 }
 
 export default class FilterOrigin {
@@ -12,11 +16,21 @@ export default class FilterOrigin {
   option_name?: string
   category_name?: string
   category_param?: string
+  state?: GenericFilterState
+  created_at?: Date
+  updated_at?: Date
 
   constructor(filterOrigin: FilterOriginType) {
+    const currentDate = new Date()
+    const vietnamTimezoneOffset = 7 * 60
+    const localTime = new Date(currentDate.getTime() + vietnamTimezoneOffset * 60 * 1000)
+
     this._id = filterOrigin._id || new ObjectId()
     this.option_name = filterOrigin.option_name || ''
     this.category_name = filterOrigin.category_name || ''
     this.category_param = filterOrigin.category_param || ''
+    this.state = filterOrigin.state || GenericFilterState.ACTIVE
+    this.created_at = filterOrigin.created_at || localTime
+    this.updated_at = filterOrigin.updated_at || localTime
   }
 }

--- a/backend/src/models/schemas/FilterHskUses.schema.ts
+++ b/backend/src/models/schemas/FilterHskUses.schema.ts
@@ -1,10 +1,14 @@
 import { ObjectId } from 'mongodb'
+import { GenericFilterState } from '~/constants/enums'
 
 interface FilterHskUsesType {
   _id?: ObjectId
   option_name?: string
   category_name?: string
   category_param?: string
+  state?: GenericFilterState
+  created_at?: Date
+  updated_at?: Date
 }
 
 export default class FilterHskUses {
@@ -12,11 +16,21 @@ export default class FilterHskUses {
   option_name?: string
   category_name?: string
   category_param?: string
+  state?: GenericFilterState
+  created_at?: Date
+  updated_at?: Date
 
   constructor(filterHskUses: FilterHskUsesType) {
+    const currentDate = new Date()
+    const vietnamTimezoneOffset = 7 * 60
+    const localTime = new Date(currentDate.getTime() + vietnamTimezoneOffset * 60 * 1000)
+
     this._id = filterHskUses._id || new ObjectId()
     this.option_name = filterHskUses.option_name || ''
     this.category_name = filterHskUses.category_name || ''
     this.category_param = filterHskUses.category_param || ''
+    this.state = filterHskUses.state || GenericFilterState.ACTIVE
+    this.created_at = filterHskUses.created_at || localTime
+    this.updated_at = filterHskUses.updated_at || localTime
   }
 }

--- a/backend/src/routes/admin.routes.ts
+++ b/backend/src/routes/admin.routes.ts
@@ -43,7 +43,7 @@ import {
   searchFilterBrandsController,
   updateFilterBrandController
 } from '~/controllers/filterBrand.controllers'
-import { disableFilterBrandReqBody, disableFilterDacTinhReqBody, disableFilterHskIngredientReqBody, disableFilterHskProductTypeReqBody, disableFilterHskSizeReqBody, disableFilterHskSkinTypeReqBody, disableFilterHskUsesReqBody, updateFilterBrandReqBody, updateFilterDacTinhReqBody, updateFilterHskIngredientReqBody, updateFilterHskProductTypeReqBody, updateFilterHskSizeReqBody, updateFilterHskSkinTypeReqBody, updateFilterHskUsesReqBody } from '~/models/requests/Admin.requests'
+import { disableFilterBrandReqBody, disableFilterDacTinhReqBody, disableFilterHskIngredientReqBody, disableFilterHskOriginReqBody, disableFilterHskProductTypeReqBody, disableFilterHskSizeReqBody, disableFilterHskSkinTypeReqBody, disableFilterHskUsesReqBody, updateFilterBrandReqBody, updateFilterDacTinhReqBody, updateFilterHskIngredientReqBody, updateFilterHskOriginReqBody, updateFilterHskProductTypeReqBody, updateFilterHskSizeReqBody, updateFilterHskSkinTypeReqBody, updateFilterHskUsesReqBody } from '~/models/requests/Admin.requests'
 import {
   disableFilterBrandValidator,
   getFilterBrandByIdValidator,
@@ -61,6 +61,8 @@ import { createNewFilterHskSkinTypeController, disableFilterHskSkinTypeControlle
 import { createNewFilterHskSkinTypeValidator, disableFilterHskSkinTypeValidator, getFilterHskSkinTypeByIdValidator, updateFilterHskSkinTypeValidator } from '~/middlewares/filterHskSkinType.middlewares'
 import { createNewFilterHskUsesController, disableFilterHskUsesController, getAllFilterHskUsesController, getFilterHskUsesByIdController, searchFilterHskUsesController, updateFilterHskUsesController } from '~/controllers/filterHskUses.controllers'
 import { createNewFilterHskUsesValidator, disableFilterHskUsesValidator, getFilterHskUsesByIdValidator, updateFilterHskUsesValidator } from '~/middlewares/filterHskUses.middlewares'
+import { createNewFilterHskOriginController, disableFilterHskOriginController, getAllFilterHskOriginsController, getFilterHskOriginByIdController, searchFilterHskOriginsController, updateFilterHskOriginController } from '~/controllers/filterHskOrigin.controllers'
+import { createNewFilterHskOriginValidator, disableFilterHskOriginValidator, getFilterHskOriginByIdValidator, updateFilterHskOriginValidator } from '~/middlewares/filterHskOrigin.middlewares'
 
 const adminRouter = Router()
 //user management
@@ -555,5 +557,55 @@ adminRouter.put(
   filterMiddleware<disableFilterHskUsesReqBody>(['state']),
   disableFilterHskUsesValidator,
   wrapAsync(disableFilterHskUsesController)
+)
+
+//HSK ORIGIN FILTER
+adminRouter.get(
+  '/manage-filters/get-all-filter-hsk-origins',
+  accessTokenValidator,
+  isAdminValidator,
+  wrapAsync(getAllFilterHskOriginsController)
+)
+
+adminRouter.post(
+  '/manage-filters/create-new-filter-hsk-origin',
+  accessTokenValidator,
+  isAdminValidator,
+  createNewFilterHskOriginValidator,
+  wrapAsync(createNewFilterHskOriginController)
+)
+
+adminRouter.get(
+  '/manage-filters/search-filter-hsk-origin',
+  accessTokenValidator,
+  isAdminValidator,
+  searchFilterOptionNameValidator,
+  wrapAsync(searchFilterHskOriginsController)
+)
+
+adminRouter.get(
+  '/manage-filters/get-filter-hsk-origin-detail/:_id',
+  accessTokenValidator,
+  isAdminValidator,
+  getFilterHskOriginByIdValidator,
+  wrapAsync(getFilterHskOriginByIdController)
+)
+
+adminRouter.put(
+  '/manage-filters/update-filter-hsk-origin/:_id',
+  accessTokenValidator,
+  isAdminValidator,
+  filterMiddleware<updateFilterHskOriginReqBody>(['option_name', 'category_name', 'category_param']),
+  updateFilterHskOriginValidator,
+  wrapAsync(updateFilterHskOriginController)
+)
+
+adminRouter.put(
+  '/manage-filters/update-filter-hsk-origin-state/:_id',
+  accessTokenValidator,
+  isAdminValidator,
+  filterMiddleware<disableFilterHskOriginReqBody>(['state']),
+  disableFilterHskOriginValidator,
+  wrapAsync(disableFilterHskOriginController)
 )
 export default adminRouter

--- a/backend/src/routes/admin.routes.ts
+++ b/backend/src/routes/admin.routes.ts
@@ -43,7 +43,7 @@ import {
   searchFilterBrandsController,
   updateFilterBrandController
 } from '~/controllers/filterBrand.controllers'
-import { disableFilterBrandReqBody, disableFilterDacTinhReqBody, disableFilterHskIngredientReqBody, disableFilterHskProductTypeReqBody, disableFilterHskSizeReqBody, disableFilterHskSkinTypeReqBody, updateFilterBrandReqBody, updateFilterDacTinhReqBody, updateFilterHskIngredientReqBody, updateFilterHskProductTypeReqBody, updateFilterHskSizeReqBody, updateFilterHskSkinTypeReqBody } from '~/models/requests/Admin.requests'
+import { disableFilterBrandReqBody, disableFilterDacTinhReqBody, disableFilterHskIngredientReqBody, disableFilterHskProductTypeReqBody, disableFilterHskSizeReqBody, disableFilterHskSkinTypeReqBody, disableFilterHskUsesReqBody, updateFilterBrandReqBody, updateFilterDacTinhReqBody, updateFilterHskIngredientReqBody, updateFilterHskProductTypeReqBody, updateFilterHskSizeReqBody, updateFilterHskSkinTypeReqBody, updateFilterHskUsesReqBody } from '~/models/requests/Admin.requests'
 import {
   disableFilterBrandValidator,
   getFilterBrandByIdValidator,
@@ -59,6 +59,8 @@ import { createNewFilterHskSizeController, disableFilterHskSizeController, getAl
 import { createNewFilterHskSizeValidator, disableFilterHskSizeValidator, getFilterHskSizeByIdValidator, updateFilterHskSizeValidator } from '~/middlewares/filterHskSize.middlewares'
 import { createNewFilterHskSkinTypeController, disableFilterHskSkinTypeController, getAllFilterHskSkinTypesController, getFilterHskSkinTypeByIdController, searchFilterHskSkinTypesController, updateFilterHskSkinTypeController } from '~/controllers/filterHskSkinType.controllers'
 import { createNewFilterHskSkinTypeValidator, disableFilterHskSkinTypeValidator, getFilterHskSkinTypeByIdValidator, updateFilterHskSkinTypeValidator } from '~/middlewares/filterHskSkinType.middlewares'
+import { createNewFilterHskUsesController, disableFilterHskUsesController, getAllFilterHskUsesController, getFilterHskUsesByIdController, searchFilterHskUsesController, updateFilterHskUsesController } from '~/controllers/filterHskUses.controllers'
+import { createNewFilterHskUsesValidator, disableFilterHskUsesValidator, getFilterHskUsesByIdValidator, updateFilterHskUsesValidator } from '~/middlewares/filterHskUses.middlewares'
 
 const adminRouter = Router()
 //user management
@@ -503,5 +505,55 @@ adminRouter.put(
   filterMiddleware<disableFilterHskSkinTypeReqBody>(['state']),
   disableFilterHskSkinTypeValidator,
   wrapAsync(disableFilterHskSkinTypeController)
+)
+
+//HSK USES FILTER
+adminRouter.get(
+  '/manage-filters/get-all-filter-hsk-uses',
+  accessTokenValidator,
+  isAdminValidator,
+  wrapAsync(getAllFilterHskUsesController)
+)
+
+adminRouter.post(
+  '/manage-filters/create-new-filter-hsk-uses',
+  accessTokenValidator,
+  isAdminValidator,
+  createNewFilterHskUsesValidator,
+  wrapAsync(createNewFilterHskUsesController)
+)
+
+adminRouter.get(
+  '/manage-filters/search-filter-hsk-uses',
+  accessTokenValidator,
+  isAdminValidator,
+  searchFilterOptionNameValidator,
+  wrapAsync(searchFilterHskUsesController)
+)
+
+adminRouter.get(
+  '/manage-filters/get-filter-hsk-uses-detail/:_id',
+  accessTokenValidator,
+  isAdminValidator,
+  getFilterHskUsesByIdValidator,
+  wrapAsync(getFilterHskUsesByIdController)
+)
+
+adminRouter.put(
+  '/manage-filters/update-filter-hsk-uses/:_id',
+  accessTokenValidator,
+  isAdminValidator,
+  filterMiddleware<updateFilterHskUsesReqBody>(['option_name', 'category_name', 'category_param']),
+  updateFilterHskUsesValidator,
+  wrapAsync(updateFilterHskUsesController)
+)
+
+adminRouter.put(
+  '/manage-filters/update-filter-hsk-uses-state/:_id',
+  accessTokenValidator,
+  isAdminValidator,
+  filterMiddleware<disableFilterHskUsesReqBody>(['state']),
+  disableFilterHskUsesValidator,
+  wrapAsync(disableFilterHskUsesController)
 )
 export default adminRouter

--- a/backend/src/routes/admin.routes.ts
+++ b/backend/src/routes/admin.routes.ts
@@ -38,6 +38,7 @@ import { getOrderRevenueValidator } from '~/middlewares/orders.middlewares'
 import { updateProductReqBody } from '~/models/requests/Product.requests'
 import {
   disableFilterBrandController,
+  getActiveFilterBrandsController,
   getAllFilterBrandsController,
   getFilterBrandByIdController,
   searchFilterBrandsController,
@@ -50,18 +51,18 @@ import {
   updateFilterBrandValidator
 } from '~/middlewares/filterBrand.middlewares'
 import { createNewFilterDacTinhValidator, disableFilterDacTinhValidator, getFilterDacTinhByIdValidator, updateFilterDacTinhValidator } from '~/middlewares/filterDacTinh.middlewares'
-import { createNewFilterDacTinhController, disableFilterDacTinhController, getAllFilterDacTinhsController, getFilterDacTinhByIdController, searchFilterDacTinhsController, updateFilterDacTinhController } from '~/controllers/filterDacTinh.controllers'
-import { createNewFilterHskIngredientController, disableFilterHskIngredientController, getAllFilterHskIngredientsController, getFilterHskIngredientByIdController, searchFilterHskIngredientsController, updateFilterHskIngredientController } from '~/controllers/filterHskIngredient.controllers'
+import { createNewFilterDacTinhController, disableFilterDacTinhController, getActiveFilterDacTinhsController, getAllFilterDacTinhsController, getFilterDacTinhByIdController, searchFilterDacTinhsController, updateFilterDacTinhController } from '~/controllers/filterDacTinh.controllers'
+import { createNewFilterHskIngredientController, disableFilterHskIngredientController, getActiveFilterHskIngredientsController, getAllFilterHskIngredientsController, getFilterHskIngredientByIdController, searchFilterHskIngredientsController, updateFilterHskIngredientController } from '~/controllers/filterHskIngredient.controllers'
 import { createNewFilterHskIngredientValidator, disableFilterHskIngredientValidator, getFilterHskIngredientByIdValidator, updateFilterHskIngredientValidator } from '~/middlewares/filterHskIngredient.middlewares'
-import { createNewFilterHskProductTypeController, disableFilterHskProductTypeController, getAllFilterHskProductTypesController, getFilterHskProductTypeByIdController, searchFilterHskProductTypesController, updateFilterHskProductTypeController } from '~/controllers/filterHskProductType.controllers'
+import { createNewFilterHskProductTypeController, disableFilterHskProductTypeController, getActiveFilterHskProductTypesController, getAllFilterHskProductTypesController, getFilterHskProductTypeByIdController, searchFilterHskProductTypesController, updateFilterHskProductTypeController } from '~/controllers/filterHskProductType.controllers'
 import { createNewFilterHskProductTypeValidator, disableFilterHskProductTypeValidator, getFilterHskProductTypeByIdValidator, updateFilterHskProductTypeValidator } from '~/middlewares/filterHskProductType.middlewares'
-import { createNewFilterHskSizeController, disableFilterHskSizeController, getAllFilterHskSizesController, getFilterHskSizeByIdController, searchFilterHskSizesController, updateFilterHskSizeController } from '~/controllers/filterHskSize.controllers'
+import { createNewFilterHskSizeController, disableFilterHskSizeController, getActiveFilterHskSizesController, getAllFilterHskSizesController, getFilterHskSizeByIdController, searchFilterHskSizesController, updateFilterHskSizeController } from '~/controllers/filterHskSize.controllers'
 import { createNewFilterHskSizeValidator, disableFilterHskSizeValidator, getFilterHskSizeByIdValidator, updateFilterHskSizeValidator } from '~/middlewares/filterHskSize.middlewares'
-import { createNewFilterHskSkinTypeController, disableFilterHskSkinTypeController, getAllFilterHskSkinTypesController, getFilterHskSkinTypeByIdController, searchFilterHskSkinTypesController, updateFilterHskSkinTypeController } from '~/controllers/filterHskSkinType.controllers'
+import { createNewFilterHskSkinTypeController, disableFilterHskSkinTypeController, getActiveFilterHskSkinTypesController, getAllFilterHskSkinTypesController, getFilterHskSkinTypeByIdController, searchFilterHskSkinTypesController, updateFilterHskSkinTypeController } from '~/controllers/filterHskSkinType.controllers'
 import { createNewFilterHskSkinTypeValidator, disableFilterHskSkinTypeValidator, getFilterHskSkinTypeByIdValidator, updateFilterHskSkinTypeValidator } from '~/middlewares/filterHskSkinType.middlewares'
-import { createNewFilterHskUsesController, disableFilterHskUsesController, getAllFilterHskUsesController, getFilterHskUsesByIdController, searchFilterHskUsesController, updateFilterHskUsesController } from '~/controllers/filterHskUses.controllers'
+import { createNewFilterHskUsesController, disableFilterHskUsesController, getActiveFilterHskUsesController, getAllFilterHskUsesController, getFilterHskUsesByIdController, searchFilterHskUsesController, updateFilterHskUsesController } from '~/controllers/filterHskUses.controllers'
 import { createNewFilterHskUsesValidator, disableFilterHskUsesValidator, getFilterHskUsesByIdValidator, updateFilterHskUsesValidator } from '~/middlewares/filterHskUses.middlewares'
-import { createNewFilterHskOriginController, disableFilterHskOriginController, getAllFilterHskOriginsController, getFilterHskOriginByIdController, searchFilterHskOriginsController, updateFilterHskOriginController } from '~/controllers/filterHskOrigin.controllers'
+import { createNewFilterHskOriginController, disableFilterHskOriginController, getActiveFilterHskOriginsController, getAllFilterHskOriginsController, getFilterHskOriginByIdController, searchFilterHskOriginsController, updateFilterHskOriginController } from '~/controllers/filterHskOrigin.controllers'
 import { createNewFilterHskOriginValidator, disableFilterHskOriginValidator, getFilterHskOriginByIdValidator, updateFilterHskOriginValidator } from '~/middlewares/filterHskOrigin.middlewares'
 
 const adminRouter = Router()
@@ -607,5 +608,55 @@ adminRouter.put(
   filterMiddleware<disableFilterHskOriginReqBody>(['state']),
   disableFilterHskOriginValidator,
   wrapAsync(disableFilterHskOriginController)
+)
+
+//get active filter
+adminRouter.get(
+  '/manage-filters/get-active-filter-brands',
+  accessTokenValidator,
+  isAdminValidator,
+  wrapAsync(getActiveFilterBrandsController)
+)
+adminRouter.get(
+  '/manage-filters/get-active-filter-dac-tinhs',
+  accessTokenValidator,
+  isAdminValidator,
+  wrapAsync(getActiveFilterDacTinhsController)
+)
+adminRouter.get(
+  '/manage-filters/get-active-filter-hsk-ingredients',
+  accessTokenValidator,
+  isAdminValidator,
+  wrapAsync(getActiveFilterHskIngredientsController)
+)
+adminRouter.get(
+  '/manage-filters/get-active-filter-hsk-product-types',
+  accessTokenValidator,
+  isAdminValidator,
+  wrapAsync(getActiveFilterHskProductTypesController)
+)
+adminRouter.get(
+  '/manage-filters/get-active-filter-hsk-sizes',
+  accessTokenValidator,
+  isAdminValidator,
+  wrapAsync(getActiveFilterHskSizesController)
+)
+adminRouter.get(
+  '/manage-filters/get-active-filter-hsk-skin-types',
+  accessTokenValidator,
+  isAdminValidator,
+  wrapAsync(getActiveFilterHskSkinTypesController)
+)
+adminRouter.get(
+  '/manage-filters/get-active-filter-hsk-uses',
+  accessTokenValidator,
+  isAdminValidator,
+  wrapAsync(getActiveFilterHskUsesController)
+)
+adminRouter.get(
+  '/manage-filters/get-active-filter-hsk-origins',
+  accessTokenValidator,
+  isAdminValidator,
+  wrapAsync(getActiveFilterHskOriginsController)
 )
 export default adminRouter

--- a/backend/src/services/filterHskUses.services.ts
+++ b/backend/src/services/filterHskUses.services.ts
@@ -1,4 +1,10 @@
 import { ObjectId } from 'mongodb'
+import { GenericFilterState } from '~/constants/enums'
+import HTTP_STATUS from '~/constants/httpStatus'
+import { ADMIN_MESSAGES } from '~/constants/messages'
+import { ErrorWithStatus } from '~/models/Errors'
+import { createNewFilterHskUsesReqBody, updateFilterHskUsesReqBody } from '~/models/requests/Admin.requests'
+import FilterHskUses from '~/models/schemas/FilterHskUses.schema'
 import databaseService from '~/services/database.services'
 
 class FilterHskUsesService {
@@ -7,6 +13,49 @@ class FilterHskUsesService {
       _id: new ObjectId(filter_hsk_uses)
     })
     return Boolean(uses)
+  }
+
+  async createNewFilterUses(payload: createNewFilterHskUsesReqBody) {
+    const filterID = new ObjectId()
+    const currentDate = new Date()
+    const vietnamTimezoneOffset = 7 * 60
+    const localTime = new Date(currentDate.getTime() + vietnamTimezoneOffset * 60 * 1000)
+
+    const result = await databaseService.filterHskUses.insertOne(
+      new FilterHskUses({
+        ...payload,
+        _id: filterID,
+        state: payload.state || GenericFilterState.ACTIVE,
+        created_at: localTime,
+        updated_at: localTime
+      })
+    )
+    return result
+  }
+
+  async updateFilterUses(_id: string, payload: updateFilterHskUsesReqBody) {
+    try {
+      const currentDate = new Date()
+      const vietnamTimezoneOffset = 7 * 60
+      const localTime = new Date(currentDate.getTime() + vietnamTimezoneOffset * 60 * 1000)
+
+      const result = await databaseService.filterHskUses.findOneAndUpdate(
+        { _id: new ObjectId(_id) },
+        {
+          $set: {
+            ...payload,
+            updated_at: localTime
+          }
+        },
+        { returnDocument: 'after' }
+      )
+      return result
+    } catch (error) {
+      throw new ErrorWithStatus({
+        message: ADMIN_MESSAGES.UPDATE_FILTER_USES_FAILED,
+        status: HTTP_STATUS.INTERNAL_SERVER_ERROR
+      })
+    }
   }
 }
 const filterHskUsesService = new FilterHskUsesService()

--- a/backend/src/services/filterOrigin.services.ts
+++ b/backend/src/services/filterOrigin.services.ts
@@ -1,4 +1,10 @@
 import { ObjectId } from 'mongodb'
+import { GenericFilterState } from '~/constants/enums'
+import HTTP_STATUS from '~/constants/httpStatus'
+import { ADMIN_MESSAGES } from '~/constants/messages'
+import { ErrorWithStatus } from '~/models/Errors'
+import { createNewFilterHskOriginReqBody, updateFilterHskOriginReqBody } from '~/models/requests/Admin.requests'
+import FilterOrigin from '~/models/schemas/FilterHskOrigin.schema'
 import databaseService from '~/services/database.services'
 
 class FilterOriginService {
@@ -7,6 +13,49 @@ class FilterOriginService {
       _id: new ObjectId(filter_origin)
     })
     return Boolean(origin)
+  }
+
+  async createNewFilterOrigin(payload: createNewFilterHskOriginReqBody) {
+    const filterID = new ObjectId()
+    const currentDate = new Date()
+    const vietnamTimezoneOffset = 7 * 60
+    const localTime = new Date(currentDate.getTime() + vietnamTimezoneOffset * 60 * 1000)
+
+    const result = await databaseService.filterOrigin.insertOne(
+      new FilterOrigin({
+        ...payload,
+        _id: filterID,
+        state: payload.state || GenericFilterState.ACTIVE,
+        created_at: localTime,
+        updated_at: localTime
+      })
+    )
+    return result
+  }
+
+  async updateFilterOrigin(_id: string, payload: updateFilterHskOriginReqBody) {
+    try {
+      const currentDate = new Date()
+      const vietnamTimezoneOffset = 7 * 60
+      const localTime = new Date(currentDate.getTime() + vietnamTimezoneOffset * 60 * 1000)
+
+      const result = await databaseService.filterOrigin.findOneAndUpdate(
+        { _id: new ObjectId(_id) },
+        {
+          $set: {
+            ...payload,
+            updated_at: localTime
+          }
+        },
+        { returnDocument: 'after' }
+      )
+      return result
+    } catch (error) {
+      throw new ErrorWithStatus({
+        message: ADMIN_MESSAGES.UPDATE_FILTER_ORIGIN_FAILED,
+        status: HTTP_STATUS.INTERNAL_SERVER_ERROR
+      })
+    }
   }
 }
 const filterOriginService = new FilterOriginService()


### PR DESCRIPTION
Pull request này bổ sung các chức năng CRUD (Tạo, Đọc, Cập nhật, Xóa) hoàn chỉnh cho hai loại bộ lọc mới: "Công dụng" (uses) và "Nguồn gốc" (origin). Các chức năng này cho phép quản trị viên quản lý hiệu quả các tùy chọn bộ lọc có sẵn cho sản phẩm.

Ngoài ra, pull request này cũng triển khai các cải tiến quan trọng về validation và bổ sung các endpoints mới để tối ưu hóa việc lấy dữ liệu bộ lọc phía client.

Các thay đổi chính:

✨ CRUD cho Bộ lọc "Công dụng" (uses):

POST /admin/manage-filters/create-new-filter-hsk-uses: Tạo một tùy chọn "công dụng" mới.

GET /admin/manage-filters/get-all-filter-hsk-uses: Lấy danh sách tất cả các tùy chọn "công dụng" (hỗ trợ phân trang).

GET /admin/manage-filters/get-filter-hsk-uses-detail/:_id: Lấy chi tiết một tùy chọn "công dụng" theo ID.

PUT /admin/manage-filters/update-filter-hsk-uses/:_id: Cập nhật thông tin một tùy chọn "công dụng".

PUT /admin/manage-filters/update-filter-hsk-uses-state/:_id: Cập nhật trạng thái (active/inactive) của một tùy chọn.

GET /admin/manage-filters/search-filter-hsk-uses: Tìm kiếm các tùy chọn "công dụng".

✨ CRUD cho Bộ lọc "Nguồn gốc" (origin):

POST /admin/manage-filters/create-new-filter-hsk-origin: Tạo một tùy chọn "nguồn gốc" mới.

GET /admin/manage-filters/get-all-filter-hsk-origins: Lấy danh sách tất cả các tùy chọn "nguồn gốc" (hỗ trợ phân trang).

GET /admin/manage-filters/get-filter-hsk-origin-detail/:_id: Lấy chi tiết một tùy chọn "nguồn gốc" theo ID.

PUT /admin/manage-filters/update-filter-hsk-origin/:_id: Cập nhật thông tin một tùy chọn "nguồn gốc".

PUT /admin/manage-filters/update-filter-hsk-origin-state/:_id: Cập nhật trạng thái (active/inactive) của một tùy chọn.

GET /admin/manage-filters/search-filter-hsk-origin: Tìm kiếm các tùy chọn "nguồn gốc".

🛡️ Cải tiến Validation:

Thêm logic validation để ngăn chặn việc cập nhật thông tin của bất kỳ bộ lọc nào (Brand, Dac Tinh, Ingredient, Product Type, Size, Skin Type, Uses, Origin) khi chúng đang ở trạng thái INACTIVE. Điều này đảm bảo tính toàn vẹn dữ liệu và tránh các thao tác không mong muốn.

Bổ sung các thông báo lỗi (error messages) rõ ràng để hướng dẫn người dùng khi họ cố gắng tương tác với các bộ lọc không hợp lệ hoặc không hoạt động.

🚀 Endpoints lấy bộ lọc "Active":

Triển khai một loạt các endpoints GET /admin/manage-filters/get-active-filter-* cho tất cả các loại bộ lọc.

Các endpoints này chỉ trả về danh sách các bộ lọc có trạng thái "active" (hoặc các trạng thái được coi là hợp lệ để sử dụng khi tạo/cập nhật sản phẩm). Điều này giúp giảm tải cho client và đơn giản hóa logic ở frontend khi cần hiển thị các tùy chọn bộ lọc cho quản trị viên.

📄 Cập nhật tài liệu Swagger UI:

Tất cả các endpoints mới và các schema liên quan (request body, response) đã được τεκμηριωθεί đầy đủ trong openapi.json để đảm bảo tính nhất quán và dễ dàng cho việc kiểm thử và tích hợp.