### PR TITLE
feat: Add AI usage statistics feature with chart and stats components

### DIFF
--- a/frontend/src/api/aiusage.ts
+++ b/frontend/src/api/aiusage.ts
@@ -1,0 +1,9 @@
+import httpClient from "@/lib/axios";
+import type { AIUsageRecord } from "@/types/aiusage";
+
+//get-ai-usage
+export const fetchAIUsage = async () => {
+  return await httpClient
+    .get<API.IResponseAPI<AIUsageRecord>>("/admin/ai-usage-stats")
+    .then((response) => response.data);
+};

--- a/frontend/src/components/Sidebar/index.tsx
+++ b/frontend/src/components/Sidebar/index.tsx
@@ -1,4 +1,5 @@
 import {
+  BotIcon,
   Droplet,
   FileX2,
   FlaskConical,
@@ -87,6 +88,11 @@ const items = [
     title: "Quản lý bài viết",
     url: "/admin/posts",
     icon: StickyNote,
+  },
+  {
+    title: "Thống kê AI",
+    url: "/admin/ai-statistics",
+    icon: BotIcon,
   },
 ];
 const AppSidebar: React.FC = () => {

--- a/frontend/src/features/Admin/AI-Usage/components/AIUsageChart.tsx
+++ b/frontend/src/features/Admin/AI-Usage/components/AIUsageChart.tsx
@@ -1,0 +1,304 @@
+import { BarChart3, LineChart as LineIcon, TrendingUp } from "lucide-react";
+import { useState } from "react";
+import {
+  Area,
+  AreaChart,
+  Bar,
+  CartesianGrid,
+  ComposedChart,
+  Legend,
+  Line,
+  LineChart,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import type { DailyAIUsage } from "@/types/aiusage.d";
+
+interface AIUsageChartProps {
+  data: DailyAIUsage[];
+}
+
+const formatChartData = (data: DailyAIUsage[]) => {
+  const sortedData = [...data].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
+
+  return sortedData.map((item, index) => {
+    const previousCount = index > 0 ? sortedData[index - 1].count : item.count;
+    const trend = index > 0 ? item.count - previousCount : 0;
+
+    return {
+      date: new Date(item.date).toLocaleDateString("vi-VN", {
+        month: "short",
+        day: "numeric",
+      }),
+      count: item.count,
+      trend: trend,
+      movingAvg:
+        index >= 2
+          ? Math.round(
+              sortedData.slice(Math.max(0, index - 2), index + 1).reduce((sum, d) => sum + d.count, 0) /
+                Math.min(3, index + 1)
+            )
+          : item.count,
+      fullDate: new Date(item.date).toLocaleDateString("vi-VN"),
+      dayOfWeek: new Date(item.date).toLocaleDateString("vi-VN", { weekday: "short" }),
+    };
+  });
+};
+
+export const AIUsageChart: React.FC<AIUsageChartProps> = ({ data }) => {
+  const [chartType, setChartType] = useState<"area" | "line" | "composed">("area");
+  const chartData = formatChartData(data);
+
+  const average =
+    chartData.length > 0 ? Math.round(chartData.reduce((sum, item) => sum + item.count, 0) / chartData.length) : 0;
+
+  const CustomTooltip = ({ active, payload }: any) => {
+    if (active && payload && payload.length) {
+      const data = payload[0].payload;
+      return (
+        <div className="min-w-[200px] rounded-lg border bg-white p-4 shadow-lg">
+          <div className="mb-2 border-b pb-2">
+            <p className="font-semibold text-gray-900">
+              {data.dayOfWeek}, {data.fullDate}
+            </p>
+          </div>
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <span className="text-gray-600">Lượt sử dụng:</span>
+              <span className="font-bold text-blue-600">{data.count}</span>
+            </div>
+            <div className="flex items-center justify-between">
+              <span className="text-gray-600">Trung bình 3 ngày:</span>
+              <span className="font-medium text-purple-600">{data.movingAvg}</span>
+            </div>
+            {data.trend !== 0 && (
+              <div className="flex items-center justify-between">
+                <span className="text-gray-600">So với hôm trước:</span>
+                <span className={`font-medium ${data.trend > 0 ? "text-green-600" : "text-red-600"}`}>
+                  {data.trend > 0 ? "+" : ""}
+                  {data.trend}
+                </span>
+              </div>
+            )}
+          </div>
+        </div>
+      );
+    }
+    return null;
+  };
+
+  const renderChart = () => {
+    const commonProps = {
+      data: chartData,
+      margin: { top: 20, right: 30, left: 20, bottom: 5 },
+    };
+
+    switch (chartType) {
+      case "area":
+        return (
+          <AreaChart {...commonProps}>
+            <defs>
+              <linearGradient id="usageGradient" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="#3b82f6" stopOpacity={0.3} />
+                <stop offset="95%" stopColor="#3b82f6" stopOpacity={0.05} />
+              </linearGradient>
+              <linearGradient id="avgGradient" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="#8b5cf6" stopOpacity={0.2} />
+                <stop offset="95%" stopColor="#8b5cf6" stopOpacity={0.02} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+            <XAxis
+              dataKey="date"
+              stroke="#6b7280"
+              fontSize={11}
+              tickLine={false}
+              axisLine={false}
+              tick={{ fill: "#6b7280" }}
+            />
+            <YAxis
+              stroke="#6b7280"
+              fontSize={11}
+              tickLine={false}
+              axisLine={false}
+              tick={{ fill: "#6b7280" }}
+              tickFormatter={(value) => `${value}`}
+            />
+            <Tooltip content={<CustomTooltip />} />
+            <Legend wrapperStyle={{ paddingTop: "20px" }} iconType="line" />
+            <ReferenceLine
+              y={average}
+              stroke="#ef4444"
+              strokeDasharray="5 5"
+              label={{ value: `Trung bình: ${average}`, position: "top" }}
+            />
+            <Area
+              type="monotone"
+              dataKey="count"
+              stroke="#3b82f6"
+              strokeWidth={3}
+              fill="url(#usageGradient)"
+              name="Lượt sử dụng"
+              dot={{ fill: "#3b82f6", strokeWidth: 2, r: 4 }}
+              activeDot={{ r: 6, stroke: "#3b82f6", strokeWidth: 2, fill: "#ffffff" }}
+            />
+            <Area
+              type="monotone"
+              dataKey="movingAvg"
+              stroke="#8b5cf6"
+              strokeWidth={2}
+              strokeDasharray="8 4"
+              fill="url(#avgGradient)"
+              name="Trung bình 3 ngày"
+              dot={false}
+            />
+          </AreaChart>
+        );
+
+      case "composed":
+        return (
+          <ComposedChart {...commonProps}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+            <XAxis dataKey="date" stroke="#6b7280" fontSize={11} tickLine={false} axisLine={false} />
+            <YAxis
+              stroke="#6b7280"
+              fontSize={11}
+              tickLine={false}
+              axisLine={false}
+              tickFormatter={(value) => `${value}`}
+            />
+            <Tooltip content={<CustomTooltip />} />
+            <Legend wrapperStyle={{ paddingTop: "20px" }} />
+            <Bar dataKey="count" fill="#3b82f6" fillOpacity={0.6} name="Lượt sử dụng" radius={[4, 4, 0, 0]} />
+            <Line
+              type="monotone"
+              dataKey="movingAvg"
+              stroke="#8b5cf6"
+              strokeWidth={3}
+              name="Trung bình 3 ngày"
+              dot={{ fill: "#8b5cf6", strokeWidth: 2, r: 3 }}
+            />
+          </ComposedChart>
+        );
+
+      default:
+        return (
+          <LineChart {...commonProps}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" />
+            <XAxis dataKey="date" stroke="#6b7280" fontSize={11} tickLine={false} axisLine={false} />
+            <YAxis
+              stroke="#6b7280"
+              fontSize={11}
+              tickLine={false}
+              axisLine={false}
+              tickFormatter={(value) => `${value}`}
+            />
+            <Tooltip content={<CustomTooltip />} />
+            <Legend wrapperStyle={{ paddingTop: "20px" }} />
+            <ReferenceLine
+              y={average}
+              stroke="#ef4444"
+              strokeDasharray="5 5"
+              label={{ value: `TB: ${average}`, position: "top" }}
+            />
+            <Line
+              type="monotone"
+              dataKey="count"
+              stroke="#3b82f6"
+              strokeWidth={3}
+              name="Lượt sử dụng"
+              dot={{ fill: "#3b82f6", strokeWidth: 2, r: 4 }}
+              activeDot={{ r: 7, stroke: "#3b82f6", strokeWidth: 2, fill: "#ffffff" }}
+            />
+            <Line
+              type="monotone"
+              dataKey="movingAvg"
+              stroke="#8b5cf6"
+              strokeWidth={2}
+              strokeDasharray="8 4"
+              name="Trung bình 3 ngày"
+              dot={false}
+            />
+          </LineChart>
+        );
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex flex-col justify-between space-y-2 sm:flex-row sm:items-center sm:space-y-0">
+          <div>
+            <CardTitle className="flex items-center gap-2">
+              <TrendingUp className="h-5 w-5 text-blue-600" />
+              Biểu đồ sử dụng AI theo ngày
+            </CardTitle>
+            <CardDescription>
+              Thống kê chi tiết {data.length} ngày gần đây • Trung bình: {average} lượt/ngày
+            </CardDescription>
+          </div>
+          <div className="flex gap-2">
+            <Button
+              variant={chartType === "area" ? "default" : "outline"}
+              size="sm"
+              onClick={() => setChartType("area")}
+              className="h-8"
+            >
+              <BarChart3 className="mr-1 h-4 w-4" />
+              Area
+            </Button>
+            <Button
+              variant={chartType === "line" ? "default" : "outline"}
+              size="sm"
+              onClick={() => setChartType("line")}
+              className="h-8"
+            >
+              <LineIcon className="mr-1 h-4 w-4" />
+              Line
+            </Button>
+            <Button
+              variant={chartType === "composed" ? "default" : "outline"}
+              size="sm"
+              onClick={() => setChartType("composed")}
+              className="h-8"
+            >
+              Mix
+            </Button>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <ResponsiveContainer width="100%" height={450}>
+          {renderChart()}
+        </ResponsiveContainer>
+
+        <div className="mt-4 border-t pt-4">
+          <div className="grid grid-cols-2 gap-4 text-sm sm:grid-cols-4">
+            <div className="text-center">
+              <div className="font-semibold text-blue-600">{Math.max(...chartData.map((d) => d.count))}</div>
+              <div className="text-gray-500">Cao nhất</div>
+            </div>
+            <div className="text-center">
+              <div className="font-semibold text-green-600">{Math.min(...chartData.map((d) => d.count))}</div>
+              <div className="text-gray-500">Thấp nhất</div>
+            </div>
+            <div className="text-center">
+              <div className="font-semibold text-purple-600">{average}</div>
+              <div className="text-gray-500">Trung bình</div>
+            </div>
+            <div className="text-center">
+              <div className="font-semibold text-orange-600">{chartData.reduce((sum, d) => sum + d.count, 0)}</div>
+              <div className="text-gray-500">Tổng cộng</div>
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/frontend/src/features/Admin/AI-Usage/components/AIUsageStats.tsx
+++ b/frontend/src/features/Admin/AI-Usage/components/AIUsageStats.tsx
@@ -1,0 +1,80 @@
+import { Clock, TrendingUp } from "lucide-react";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { DailyAIUsage } from "@/types/aiusage.d";
+
+interface AIUsageStatsProps {
+  data: DailyAIUsage[];
+}
+
+const AIUsageStats: React.FC<AIUsageStatsProps> = ({ data }) => {
+  const sortedData = [...data].sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+
+  const peakDay = data.reduce((max, day) => (day.count > max.count ? day : max), data[0] || { count: 0, date: "" });
+
+  const activeDays = data.filter((day) => day.count > 0).length;
+
+  const last7Days = sortedData.slice(0, 7);
+  const last7DaysTotal = last7Days.reduce((sum, day) => sum + day.count, 0);
+
+  // Usage trong 30 ngày gần nhất
+  const last30Days = sortedData.slice(0, Math.min(30, data.length));
+  const last30DaysTotal = last30Days.reduce((sum, day) => sum + day.count, 0);
+
+  return (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">Thống kê chi tiết</CardTitle>
+          <TrendingUp className="text-muted-foreground h-4 w-4" />
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2">
+            <div className="flex justify-between">
+              <span className="text-muted-foreground text-sm">Ngày đỉnh cao:</span>
+              <span className="text-sm font-medium">
+                {peakDay.count} lượt ({new Date(peakDay.date).toLocaleDateString("vi-VN")})
+              </span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-muted-foreground text-sm">Số ngày hoạt động:</span>
+              <span className="text-sm font-medium">
+                {activeDays}/{data.length} ngày
+              </span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-muted-foreground text-sm">7 ngày gần nhất:</span>
+              <span className="text-sm font-medium">{last7DaysTotal} lượt</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-muted-foreground text-sm">30 ngày gần nhất:</span>
+              <span className="text-sm font-medium">{last30DaysTotal} lượt</span>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">Hoạt động gần đây</CardTitle>
+          <Clock className="text-muted-foreground h-4 w-4" />
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-2">
+            {sortedData.slice(0, 5).map((day) => (
+              <div key={day._id} className="flex items-center justify-between">
+                <span className="text-muted-foreground text-sm">{new Date(day.date).toLocaleDateString("vi-VN")}</span>
+                <span className="text-sm font-medium">{day.count} lượt</span>
+              </div>
+            ))}
+            {data.length === 0 && (
+              <p className="text-muted-foreground py-2 text-center text-sm">Chưa có dữ liệu sử dụng</p>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default AIUsageStats;

--- a/frontend/src/features/Admin/AI-Usage/index.tsx
+++ b/frontend/src/features/Admin/AI-Usage/index.tsx
@@ -1,0 +1,107 @@
+import { BarChart3, Brain, Calendar, TrendingUp } from "lucide-react";
+import { useEffect } from "react";
+
+import { useHeader } from "@/contexts/header.context";
+import { useFetchAIUsage } from "@/hooks/AI-Usage/useFetchAIUsage";
+
+import { CardDemo } from "../components/Card";
+import { Loader } from "../components/Loader";
+import { AIUsageChart } from "./components/AIUsageChart.tsx";
+import AIUsageStats from "./components/AIUsageStats";
+
+const AIUsageIndex = () => {
+  const { setHeaderName } = useHeader();
+  const { loading, data, fetchAIUsageData } = useFetchAIUsage();
+
+  useEffect(() => {
+    setHeaderName("Thống kê sử dụng AI");
+  }, [setHeaderName]);
+
+  if (loading) {
+    return (
+      <div className="flex h-96 items-center justify-center">
+        <Loader />
+      </div>
+    );
+  }
+
+  const totalUsage = data?.totalUsage || 0;
+  const dailyUsage = data?.dailyUsage || [];
+
+  const today = new Date().toISOString().split("T")[0];
+  const todayUsage = dailyUsage.find((day) => day.date.split("T")[0] === today)?.count || 0;
+
+  const averageDaily =
+    dailyUsage.length > 0 ? Math.round(dailyUsage.reduce((sum, day) => sum + day.count, 0) / dailyUsage.length) : 0;
+
+  const lastWeekData = dailyUsage.slice(-14);
+  const thisWeek = lastWeekData.slice(-7).reduce((sum, day) => sum + day.count, 0);
+  const previousWeek = lastWeekData.slice(0, 7).reduce((sum, day) => sum + day.count, 0);
+  const trend = previousWeek > 0 ? Math.round(((thisWeek - previousWeek) / previousWeek) * 100) : 0;
+
+  return (
+    <div className="w-full space-y-6 bg-gray-50 p-4 md:p-6">
+      {!data && !loading && (
+        <div className="flex flex-col items-center justify-center py-12">
+          <Brain className="mb-4 h-16 w-16 text-gray-400" />
+          <h3 className="mb-2 text-lg font-medium text-gray-900">Không có dữ liệu</h3>
+          <p className="mb-4 text-gray-500">Chưa có thông tin về việc sử dụng AI.</p>
+          <button
+            onClick={fetchAIUsageData}
+            className="rounded-lg bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none"
+          >
+            Thử lại
+          </button>
+        </div>
+      )}
+
+      {data && (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          <CardDemo
+            title="Tổng lượt sử dụng"
+            amount={totalUsage.toLocaleString()}
+            icon={<Brain className="h-5 w-5 text-blue-600" />}
+          />
+          <CardDemo
+            title="Sử dụng hôm nay"
+            amount={todayUsage.toString()}
+            change={`${todayUsage > 0 ? "+" : ""}${todayUsage} lượt`}
+            icon={<Calendar className="h-5 w-5 text-green-600" />}
+          />
+          <CardDemo
+            title="Trung bình hàng ngày"
+            amount={averageDaily.toString()}
+            change={`${averageDaily} lượt/ngày`}
+            icon={<BarChart3 className="h-5 w-5 text-purple-600" />}
+          />
+          <CardDemo
+            title="Xu hướng tuần này"
+            amount={`${trend > 0 ? "+" : ""}${trend}%`}
+            change={trend > 0 ? "Tăng so với tuần trước" : trend < 0 ? "Giảm so với tuần trước" : "Không thay đổi"}
+            icon={
+              <TrendingUp
+                className={`h-5 w-5 ${trend > 0 ? "text-green-600" : trend < 0 ? "text-red-600" : "text-gray-600"}`}
+              />
+            }
+          />
+        </div>
+      )}
+      <div className="space-y-4">
+        <AIUsageChart data={dailyUsage} />
+        <AIUsageStats data={dailyUsage} />
+      </div>
+
+      <div className="flex justify-end">
+        <button
+          onClick={fetchAIUsageData}
+          className="rounded-lg bg-blue-600 px-4 py-2 text-white hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none"
+          disabled={loading}
+        >
+          {loading ? "Đang tải..." : "Làm mới dữ liệu"}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default AIUsageIndex;

--- a/frontend/src/hooks/AI-Usage/useFetchAIUsage.ts
+++ b/frontend/src/hooks/AI-Usage/useFetchAIUsage.ts
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { fetchAIUsage } from "@/api/aiusage";
+import type { AIUsageRecord } from "@/types/aiusage";
+
+export const useFetchAIUsage = () => {
+  const [loading, setLoading] = useState<boolean>(true);
+  const [data, setData] = useState<AIUsageRecord | null>(null);
+
+  const fetchAIUsageData = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await fetchAIUsage();
+      console.log(response.result);
+      setData(response.result);
+
+      console.log(data);
+    } catch (error) {
+      console.error("Failed to fetch AI usage data:", error);
+      setData(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchAIUsageData();
+  }, [fetchAIUsageData]);
+
+  return {
+    loading,
+    data,
+    fetchAIUsageData,
+  };
+};

--- a/frontend/src/routes/adminRoutes.tsx
+++ b/frontend/src/routes/adminRoutes.tsx
@@ -1,6 +1,7 @@
 import type { RouteObject } from "react-router-dom";
 
 import Admin from "@/features/Admin";
+import AIUsageIndex from "@/features/Admin/AI-Usage";
 import BrandDetail from "@/features/Admin/Brand/BrandDetail";
 import CreateBrand from "@/features/Admin/Brand/CreateBrand";
 import ManageBrand from "@/features/Admin/Brand/ManageBrand";
@@ -270,6 +271,10 @@ const adminRoutes: RouteObject[] = [
       {
         path: "posts/:slug/:id",
         element: <PostDetail />,
+      },
+      {
+        path: "ai-statistics",
+        element: <AIUsageIndex />,
       },
     ],
   },

--- a/frontend/src/types/aiusage.d.ts
+++ b/frontend/src/types/aiusage.d.ts
@@ -1,0 +1,11 @@
+export interface AIUsageRecord {
+  totalUsage: number;
+  dailyUsage: DailyAIUsage[];
+}
+export interface DailyAIUsage {
+  _id: string;
+  date: string;
+  count: number;
+  created_at: string;
+  updated_at: string;
+}


### PR DESCRIPTION
This pull request introduces a new AI usage statistics feature to the admin dashboard. It includes backend API integration, new React components for data visualization and statistics, state management hooks, and updates to navigation and routing to surface the new functionality in the admin UI.

**AI Usage Statistics Feature**

- **API Integration & Data Fetching**
  * Added `fetchAIUsage` API method in `aiusage.ts` to retrieve AI usage statistics from the backend.
  * Implemented `useFetchAIUsage` React hook for managing loading state, fetching, and caching AI usage data.

- **Data Visualization & Statistics Components**
  * Created `AIUsageChart` component to display daily AI usage with area, line, and composed charts, including tooltips and summary stats.
  * Added `AIUsageStats` component to show peak day, active days, and recent activity summaries.
  * Developed `AIUsageIndex` page to aggregate chart, stats, and summary cards for AI usage, with loading and empty states.

**Navigation & Routing Updates**

- **Sidebar & Routing**
  * Added "Thống kê AI" (AI Statistics) to the sidebar navigation and linked it to the new route. 
  * Registered `/admin/ai-statistics` route in the admin routes configuration, pointing to the new statistics page. 